### PR TITLE
fix: rename .status to .containerStatus

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -45,6 +45,7 @@ The following properties are stored on the service managed object.
 {
   "command": "\"/bin/bash /entrypoint.sh /bin/sh -c 'exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH'\"",
   "containerId": "efe670e1c55434677ff23245199dac9a2797c45c0a3ad2f4640c16e648b5adf1",
+  "containerStatus": "Exited (0) 2 weeks ago",
   "createdAt": "2023-03-04 16:57:26 +0100 CET",
   "filesystem": "0B (virtual 136MB)",
   "image": "smallstep/step-ca",
@@ -54,7 +55,7 @@ The following properties are stored on the service managed object.
   "runningFor": "3 weeks ago",
   "serviceType": "container",
   "state": "exited",
-  "status": "Exited (0) 2 weeks ago",
+  "status": "up",
   "type": "c8y_Service"
 }
 ```
@@ -68,6 +69,7 @@ The following properties are stored on the service managed object.
   "command": "\"/lib/systemd/systemd\"",
   "containerId": "33870eaa5f67ef7ef98b1e526a7f1956101ae586d4e439b1bc75af7986a549ba",
   "containerName": "tedge-device-tedge-1",
+  "containerStatus": "Up 52 minutes",
   "createdAt": "2023-04-11 13:54:42 +0200 CEST",
   "filesystem": "8.4MB (virtual 136MB)",
   "id": "921038541",
@@ -81,7 +83,7 @@ The following properties are stored on the service managed object.
   "serviceName": "tedge",
   "serviceType": "container-group",
   "state": "running",
-  "status": "Up 52 minutes",
+  "status": "up",
   "type": "c8y_Service"
 }
 ```

--- a/src/monitor/tedge-container-monitor
+++ b/src/monitor/tedge-container-monitor
@@ -476,7 +476,7 @@ check_container_info() {
             if [ -n "${NAME%% }" ]; then
                 # Escape quotes for json
                 COMMAND=$(echo "$COMMAND" | sed 's/"/\\"/g')
-                message=$(printf '{"containerId":"%s","state":"%s","status":"%s","createdAt":"%s","image":"%s","ports":"%s","networks":"%s","runningFor":"%s","filesystem":"%s","command":"%s"}' "${ID%% }" "${STATE%% }" "${STATUS%% }" "${CREATEDAT%% }" "${IMAGE%% }" "${PORTS%% }" "${NETWORKS%% }" "${RUNNINGFOR%% }" "${SIZE%% }" "${COMMAND%% }")
+                message=$(printf '{"containerId":"%s","state":"%s","containerStatus":"%s","createdAt":"%s","image":"%s","ports":"%s","networks":"%s","runningFor":"%s","filesystem":"%s","command":"%s"}' "${ID%% }" "${STATE%% }" "${STATUS%% }" "${CREATEDAT%% }" "${IMAGE%% }" "${PORTS%% }" "${NETWORKS%% }" "${RUNNINGFOR%% }" "${SIZE%% }" "${COMMAND%% }")
                 # FIXME: Change topic once tedge supports a service specific measurement topic
                 # so that the user does not need to know that the service name is prefixed with the "{device.id}_"
                 publish "c8y/inventory/managedObjects/update/${DEVICE_ID}_${NAME}" "$message"
@@ -492,7 +492,7 @@ check_container_info() {
                 if [ -n "${CLOUD_SERVICE_NAME%% }" ]; then
                     # Escape quotes for json
                     COMMAND=$(echo "$COMMAND" | sed 's/"/\\"/g')
-                    message=$(printf '{"containerId":"%s","containerName":"%s","state":"%s","status":"%s","createdAt":"%s","image":"%s","ports":"%s","networks":"%s","runningFor":"%s","filesystem":"%s","command":"%s","projectName":"%s","serviceName":"%s"}' "${ID%% }" "${NAME%% }" "${STATE%% }" "${STATUS%% }" "${CREATEDAT%% }" "${IMAGE%% }" "${PORTS%% }" "${NETWORKS%% }" "${RUNNINGFOR%% }" "${SIZE%% }" "${COMMAND%% }" "${PROJECT_NAME}" "${PROJECT_SERVICE_NAME}")
+                    message=$(printf '{"containerId":"%s","containerName":"%s","state":"%s","containerStatus":"%s","createdAt":"%s","image":"%s","ports":"%s","networks":"%s","runningFor":"%s","filesystem":"%s","command":"%s","projectName":"%s","serviceName":"%s"}' "${ID%% }" "${NAME%% }" "${STATE%% }" "${STATUS%% }" "${CREATEDAT%% }" "${IMAGE%% }" "${PORTS%% }" "${NETWORKS%% }" "${RUNNINGFOR%% }" "${SIZE%% }" "${COMMAND%% }" "${PROJECT_NAME}" "${PROJECT_SERVICE_NAME}")
                     # FIXME: Change topic once tedge supports a service specific measurement topic
                     # so that the user does not need to know that the service name is prefixed with the "{device.id}_"
                     publish "c8y/inventory/managedObjects/update/${DEVICE_ID}_${CLOUD_SERVICE_NAME}" "$message"


### PR DESCRIPTION
.status is already provided by the service health api.

Avoid overwriting the already existing .status property which is provided by the health endpoint (e.g. up/down)