### PR TITLE
fix: use c8y/measurements topic to prevent child device creation

### DIFF
--- a/src/monitor/tedge-container-monitor
+++ b/src/monitor/tedge-container-monitor
@@ -521,10 +521,13 @@ check_telemetry() {
         # shellcheck disable=SC2046,SC2116
         "$CONTAINER_CLI" stats --all --no-stream --format "{{.Name}}\t{{.CPUPerc}}\t{{.MemPerc}}\t{{.NetIO}}" $(echo "$CONTAINERS") | while IFS=$TAB read -r NAME CPU_PERC MEM_PERC NET_IO; do
             NET_IO=$(echo "$NET_IO" | sed 's/[^0-9.].*//g')
-            message=$(printf '{"container": {"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
-            # FIXME: Change topic once tedge supports a service specific measurement topic
-            # so that the user does not need to know that the service name is prefixed with the "{device.id}_"
-            publish "tedge/measurements/${DEVICE_ID}_${NAME}" "$message"
+
+            # FIXME: Use tedge/measurements/{} topic once it can be controlled to not create a child device, but instead a child service
+            TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S%z")
+            message=$(printf '{"externalSource":{"externalId":"%s","type":"c8y_Serial"},"container":{"cpu":{"value":%s},"memory":{"value":%s},"netio":{"value":%s}},"time":"%s","type":"ThinEdgeMeasurement"}' "${DEVICE_ID}_${NAME}" "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}" "${TIMESTAMP}")
+            publish "c8y/measurement/measurements/create" "$message"
+            # message=$(printf '{"container": {"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
+            # publish "tedge/measurements/${DEVICE_ID}_${NAME}" "$message"
         done
 
         debug "Collecting container-group stats"
@@ -536,10 +539,13 @@ check_telemetry() {
             # lookup compose project and service name
             CLOUD_SERVICE_NAME=$("$CONTAINER_CLI" ps -a --format "{{.Label \"com.docker.compose.project\" }}::{{.Label \"com.docker.compose.service\" }}" --filter "name=$NAME")
             NET_IO=$(echo "$NET_IO" | sed 's/[^0-9.].*//g')
-            message=$(printf '{"container": {"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
-            # FIXME: Change topic once tedge supports a service specific measurement topic
-            # so that the user does not need to know that the service name is prefixed with the "{device.id}_"
-            publish "tedge/measurements/${DEVICE_ID}_${CLOUD_SERVICE_NAME}" "$message"
+
+            # FIXME: Use tedge/measurements/{} topic once it can be controlled to not create a child device, but instead a child service
+            TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S%z")
+            message=$(printf '{"externalSource":{"externalId":"%s","type":"c8y_Serial"},"container":{"cpu":{"value":%s},"memory":{"value":%s},"netio":{"value":%s}},"time":"%s","type":"ThinEdgeMeasurement"}' "${CLOUD_SERVICE_NAME}" "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}" "${TIMESTAMP}")
+            publish "c8y/measurement/measurements/create" "$message"
+            # message=$(printf '{"container": {"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
+            # publish "tedge/measurements/${DEVICE_ID}_${CLOUD_SERVICE_NAME}" "$message"
         done
     fi
 }


### PR DESCRIPTION
Fix an issue where publishing to `tedge/measurements/{service_name}` generates child devices (instead of child services).

Until a dedicated topic is added to thin-edge.io, the measurements are published directly to the `c8y/measurement/measurements/create` topic.