### PR TITLE
use tedge mqtt v1 api to publish telemetry data

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -25,7 +25,7 @@ When telemetry is activated, each container will provided the following measurem
     "id": "37690075",
   },
   "time": "2023-03-29T19:13:25.693Z",
-  "type": "ThinEdgeMeasurement"
+  "type": "resource_usage"
 }
 ```
 
@@ -43,18 +43,20 @@ The following properties are stored on the service managed object.
 
 ```json
 {
-  "command": "\"/bin/bash /entrypoint.sh /bin/sh -c 'exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH'\"",
-  "containerId": "efe670e1c55434677ff23245199dac9a2797c45c0a3ad2f4640c16e648b5adf1",
-  "containerStatus": "Exited (0) 2 weeks ago",
-  "createdAt": "2023-03-04 16:57:26 +0100 CET",
-  "filesystem": "0B (virtual 136MB)",
-  "image": "smallstep/step-ca",
+  "container": {
+    "command": "\"/bin/bash /entrypoint.sh /bin/sh -c 'exec /usr/local/bin/step-ca --password-file $PWDPATH $CONFIGPATH'\"",
+    "containerId": "efe670e1c55434677ff23245199dac9a2797c45c0a3ad2f4640c16e648b5adf1",
+    "containerStatus": "Exited (0) 2 weeks ago",
+    "createdAt": "2023-03-04 16:57:26 +0100 CET",
+    "filesystem": "0B (virtual 136MB)",
+    "image": "smallstep/step-ca",
+    "networks": "bridge",
+    "ports": "",
+    "runningFor": "3 weeks ago",
+    "state": "exited",
+  },
   "name": "gallant_liskov",
-  "networks": "bridge",
-  "ports": "",
-  "runningFor": "3 weeks ago",
   "serviceType": "container",
-  "state": "exited",
   "status": "up",
   "type": "c8y_Service"
 }
@@ -66,24 +68,25 @@ The following properties are stored on the service managed object.
 
 ```json
 {
-  "command": "\"/lib/systemd/systemd\"",
-  "containerId": "33870eaa5f67ef7ef98b1e526a7f1956101ae586d4e439b1bc75af7986a549ba",
-  "containerName": "tedge-device-tedge-1",
-  "containerStatus": "Up 52 minutes",
-  "createdAt": "2023-04-11 13:54:42 +0200 CEST",
-  "filesystem": "8.4MB (virtual 136MB)",
-  "id": "921038541",
-  "image": "reubenmiller/tedge-device:0.9.0-218-gd8bd3b33-9",
+  "container": {
+    "command": "\"/lib/systemd/systemd\"",
+    "containerId": "33870eaa5f67ef7ef98b1e526a7f1956101ae586d4e439b1bc75af7986a549ba",
+    "containerName": "tedge-device-tedge-1",
+    "containerStatus": "Up 52 minutes",
+    "createdAt": "2023-04-11 13:54:42 +0200 CEST",
+    "filesystem": "8.4MB (virtual 136MB)",
+    "image": "reubenmiller/tedge-device:0.9.0-218-gd8bd3b33-9",
+    "networks": "tedge-device_default",
+    "ports": "",
+    "projectName": "tedge-device",
+    "runningFor": "52 minutes ago",
+    "serviceName": "tedge",
+    "state": "running",
+  },
   "name": "tedge-device::tedge",
-  "networks": "tedge-device_default",
-  "owner": "device_rmi_raspberrypi3",
-  "ports": "",
-  "projectName": "tedge-device",
-  "runningFor": "52 minutes ago",
-  "serviceName": "tedge",
   "serviceType": "container-group",
-  "state": "running",
   "status": "up",
-  "type": "c8y_Service"
+  "type": "c8y_Service",
+  "owner": "device_rmi_raspberrypi3"
 }
 ```

--- a/src/container
+++ b/src/container
@@ -107,6 +107,25 @@ if ! "$CONTAINER_CLI" ps >/dev/null 2>&1; then
     exit "$EXIT_FAILURE"
 fi
 
+publish_health() {
+    TOPIC_ROOT=$(tedge config get mqtt.topic_root)
+    TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+    SERVICE_NAME="$1"
+    MESSAGE="$2"
+    
+    SERVICE_TOPIC=""
+    case "$TOPIC_ID" in
+        */*//)
+            parent="$(echo "$TOPIC_ID" | sed 's/\/*$//')"
+            SERVICE_TOPIC="$parent/service/$SERVICE_NAME"
+            ;;
+    esac
+
+    if [ -n "$SERVICE_TOPIC" ]; then
+        tedge mqtt pub -r "$TOPIC_ROOT/$SERVICE_TOPIC/status/health" "$2" ||:
+    fi
+}
+
 case "$COMMAND" in
     list)
         # Get all container and lookup the image id related to it
@@ -190,7 +209,7 @@ case "$COMMAND" in
         if command -V tedge >/dev/null 2>&1; then
             log "Updating health endpoint to being uninstalled"
             MESSAGE="$(printf '{"status":"uninstalled","type":"%s"}' "${SERVICE_TYPE:-container}" )"
-            tedge mqtt pub -r "tedge/health/$MODULE_NAME" "$MESSAGE" ||:
+            publish_health "$MODULE_NAME" "$MESSAGE" ||:
         fi
         ;;
 

--- a/src/container-group
+++ b/src/container-group
@@ -105,6 +105,24 @@ if ! $COMPOSE_CLI ls >/dev/null 2>&1; then
     exit "$EXIT_FAILURE"
 fi
 
+publish_health() {
+    TOPIC_ROOT=$(tedge config get mqtt.topic_root)
+    TOPIC_ID=$(tedge config get mqtt.device_topic_id)
+    SERVICE_NAME="$1"
+    MESSAGE="$2"
+    
+    SERVICE_TOPIC=""
+    case "$TOPIC_ID" in
+        */*//)
+            parent="$(echo "$TOPIC_ID" | sed 's/\/*$//')"
+            SERVICE_TOPIC="$parent/service/$SERVICE_NAME"
+            ;;
+    esac
+
+    if [ -n "$SERVICE_TOPIC" ]; then
+        tedge mqtt pub -r "$TOPIC_ROOT/$SERVICE_TOPIC/status/health" "$2" ||:
+    fi
+}
 
 get_project_dir() {
     echo "/var/tedge-container-plugin/compose/$1"
@@ -185,7 +203,7 @@ case "$COMMAND" in
                 if [ "$item" != "::" ]; then
                     log "Updating health endpoint status to uninstalled. service=$item"
                     MESSAGE="$(printf '{"status":"uninstalled","type":"%s"}' "${GROUP_SERVICE_TYPE:-"container-group"}" )"
-                    tedge mqtt pub -r "tedge/health/$item" "$MESSAGE" ||:
+                    publish_health "$item" "$MESSAGE" ||:
                 fi
             done
         fi

--- a/src/monitor/tedge-container-monitor
+++ b/src/monitor/tedge-container-monitor
@@ -393,16 +393,6 @@ check_health() {
         NAMES="$1"
     fi
 
-    DEVICE_ID=${DEVICE_ID:-}
-    if command_exists tedge; then
-        DEVICE_ID_VALUE="$(tedge config list | grep "^device.id=" | sed 's/^.*=//g')"
-
-        if [ -n "$DEVICE_ID_VALUE" ]; then
-            debug "Using device.id found from tedge"
-            DEVICE_ID="$DEVICE_ID_VALUE"
-        fi
-    fi
-
     "$CONTAINER_CLI" ps -a --format "{{.Names}}\t{{.State}}\t{{.Labels}}" --filter "name=$NAMES" | grep -v "com.docker.compose" | while IFS=$TAB read -r NAME STATE _OTHER; do
         # Normalize state, as podman returns a human friendly output, e.g. "Exited (0) 10 seconds ago"
         STATE=${STATE%% *}
@@ -452,10 +442,6 @@ check_container_info() {
     # Collect container meta information and add it to the managed object
     #
     if [ "$META_INFO" = 1 ]; then
-        if [ -z "$DEVICE_ID" ]; then
-            warn "Skipping telemetry data as the device id is empty"
-            return
-        fi
 
         NAMES=""
         # optionally filter by specific name
@@ -497,10 +483,6 @@ check_telemetry() {
     #   docker inspect -f '{{.State.StartedAt}}    {{.State.FinishedAt}}' mqtt-broker
     #   started_at=$(date --date "$(docker inspect -f '{{.State.StartedAt}}{{.State.FinishedAt}}' mqtt-broker)" +'%s')
     if [ "$TELEMETRY" = 1 ]; then
-        if [ -z "$DEVICE_ID" ]; then
-            warn "Skipping telemetry data as the device id is empty"
-            return
-        fi
 
         debug "Collecting container stats"
         # Get list of containers which are not docker compose projects

--- a/src/monitor/tedge-container-monitor
+++ b/src/monitor/tedge-container-monitor
@@ -203,6 +203,23 @@ done
 # shellcheck disable=SC2086
 set -- $POSITIONAL
 
+# topic config
+TOPIC_ROOT=$(tedge config get mqtt.topic_root || echo 'te')
+TOPIC_ID=$(tedge config get mqtt.device_topic_id || echo 'device/main//')
+
+TOPIC_PREFIX="$TOPIC_ROOT/device/main"
+case "$TOPIC_ID" in
+    */*//)
+        parent="$(echo "$TOPIC_ID" | sed 's/\/*$//')"
+        TOPIC_PREFIX="$TOPIC_ROOT/$parent"
+        ;;
+esac
+
+publish_health() {
+    SERVICE_NAME="$1"
+    MESSAGE="$2"
+    publish_retain "$TOPIC_PREFIX/service/$SERVICE_NAME/status/health" "$MESSAGE" ||:
+}
 
 # -------------------
 # Helpers
@@ -288,7 +305,7 @@ startup(){
     info "Started background health-check listener. pid=$SUB_PID"
 
     MESSAGE=$(printf '{"status":"up","pid":"%s","type":"service"}' "$SUB_PID")
-    publish_retain "tedge/health/$SERVICE_NAME" "$MESSAGE"
+    publish_health "$SERVICE_NAME" "$MESSAGE"
 }
 
 listen() {
@@ -303,12 +320,12 @@ listen() {
         --id "mosquitto_sub_${SERVICE_NAME}" \
         -h "$MQTT_HOST" \
         -p "$MQTT_PORT" \
-        --will-topic "tedge/health/${SERVICE_NAME}" \
+        --will-topic "$TOPIC_PREFIX/service/${SERVICE_NAME}/status/health" \
         --will-payload "{\"status\":\"down\",\"type\":\"service\"}" \
         --will-retain \
-        -t 'tedge/health-check/+' \
+        -t "$TOPIC_PREFIX/service/+/cmd/health/check" \
         -F '%t' | while read -r topic; do
-            name="${topic#*/*/}"
+            name=$(echo "$topic" | cut -d/ -f 5)
             info "Checking health of $name"
             check_health "$name" || :
         done
@@ -326,7 +343,7 @@ cleanup() {
         kill "$SUB_PID" >/dev/null 2>&1 || :
     fi
     # try sending a manual message (not relying on the last will and testament)
-    publish_retain "tedge/health/$SERVICE_NAME" '{"status":"down","type":"service"}' || :
+    publish_health "$SERVICE_NAME" '{"status":"down","type":"service"}' || :
 
     info "Exiting"
     # Kill all child processes
@@ -399,10 +416,8 @@ check_health() {
                 STATUS="down"
                 ;;
         esac
-        TOPIC="tedge/health/$NAME"
         MESSAGE=$(printf '{"pid":"%s","status":"%s","type":"%s"}' "$NAME" "$STATUS" "$SERVICE_TYPE")
-
-        publish_retain "$TOPIC" "$MESSAGE"
+        publish_health "$NAME" "$MESSAGE"
     done
 
     # Check docker compose projects
@@ -410,7 +425,7 @@ check_health() {
         debug "Checking compose projects"
         # Filtering is not supported for these names!
         "$CONTAINER_CLI" ps --no-trunc --all --format "{{or .Labels \" \"}}\t{{or .State \" \"}}\t{{.Label \"com.docker.compose.project\" }}\t{{.Label \"com.docker.compose.service\" }}" | grep "com.docker.compose" | while IFS=$TAB read -r _LABELS STATE PROJECT_NAME PROJECT_SERVICE_NAME; do
-            CLOUD_SERVICE_NAME="${PROJECT_NAME}::${PROJECT_SERVICE_NAME}"
+            CLOUD_SERVICE_NAME="${PROJECT_NAME}@${PROJECT_SERVICE_NAME}"
             STATE=${STATE%% *}
             STATE=$(echo "$STATE" | tr '[:upper:]' '[:lower:]')
             info "State: service=$CLOUD_SERVICE_NAME, state=$STATE"
@@ -426,32 +441,9 @@ check_health() {
                     ;;
             esac
 
-            TOPIC="tedge/health/$CLOUD_SERVICE_NAME"
             MESSAGE=$(printf '{"pid":"%s","status":"%s","type":"%s"}' "$CLOUD_SERVICE_NAME" "$STATUS" "$GROUP_SERVICE_TYPE")
-            publish_retain "$TOPIC" "$MESSAGE"
+            publish_health "$CLOUD_SERVICE_NAME" "$MESSAGE"
         done
-
-        # TODO: Remove after validation of alternative method
-        # $COMPOSE_CLI ls -a --format pretty --filter "name=$NAMES" | tail +2 | sed 's/  \+/ /g' | while IFS=' ' read -r NAME STATE _OTHER; do
-        #     STATE=${STATE%% *}
-        #     STATE=$(echo "$STATE" | tr '[:upper:]' '[:lower:]')
-        #     debug "$COMPOSE_CLI ls -a: $STATE"
-        #     case "$STATE" in
-        #         running*|up*)
-        #             STATUS="up"
-        #             ;;
-        #         create*)
-        #             STATUS="created"
-        #             ;;
-        #         *)
-        #             STATUS="down"
-        #             ;;
-        #     esac
-        #     TOPIC="tedge/health/$NAME"
-        #     MESSAGE=$(printf '{"pid":"%s","status":"%s","type":"%s"}' "$NAME" "$STATUS" "$GROUP_SERVICE_TYPE")
-
-        #     publish_retain "$TOPIC" "$MESSAGE"
-        # done
     fi
 }
 
@@ -476,9 +468,7 @@ check_container_info() {
         "$CONTAINER_CLI" ps --no-trunc --all --filter "name=$NAMES" --format "{{.ID}}\t{{or .Names \" \"}}\t{{or .Labels \" \"}}\t{{or .State \" \"}}\t{{or .Status \" \"}}\t{{.CreatedAt}}\t{{.Image}}\t{{or .Ports \" \"}}\t{{or .Networks \" \"}}\t{{or .RunningFor \" \"}}\t{{or .Size \" \"}}\t{{json (or .Command \" \")}}" | grep -v "com.docker.compose" | while IFS=$TAB read -r ID NAME _LABELS STATE STATUS CREATEDAT IMAGE PORTS NETWORKS RUNNINGFOR SIZE COMMAND; do
             if [ -n "${NAME%% }" ]; then
                 message=$(printf '{"containerId":"%s","state":"%s","containerStatus":"%s","createdAt":"%s","image":"%s","ports":"%s","networks":"%s","runningFor":"%s","filesystem":"%s","command":%s}' "${ID%% }" "${STATE%% }" "${STATUS%% }" "${CREATEDAT%% }" "${IMAGE%% }" "${PORTS%% }" "${NETWORKS%% }" "${RUNNINGFOR%% }" "${SIZE%% }" "${COMMAND%% }")
-                # FIXME: Change topic once tedge supports a service specific measurement topic
-                # so that the user does not need to know that the service name is prefixed with the "{device.id}_"
-                publish "c8y/inventory/managedObjects/update/${DEVICE_ID}_${NAME}" "$message"
+                publish_retain "$TOPIC_PREFIX/service/$NAME/twin/container" "$message"
             fi
         done
 
@@ -488,12 +478,10 @@ check_container_info() {
             # Note: Use json template func in --format to allow docker to do the json escaping
             # --filter "name=$NAMES"
             "$CONTAINER_CLI" ps --no-trunc --all --format "{{.ID}}\t{{or .Names \" \"}}\t{{or .Labels \" \"}}\t{{or .State \" \"}}\t{{or .Status \" \"}}\t{{.CreatedAt}}\t{{.Image}}\t{{or .Ports \" \"}}\t{{or .Networks \" \"}}\t{{or .RunningFor \" \"}}\t{{or .Size \" \"}}\t{{json (or .Command \" \")}}\t{{.Label \"com.docker.compose.project\" }}\t{{.Label \"com.docker.compose.service\" }}" | grep "com.docker.compose" | while IFS=$TAB read -r ID NAME _LABELS STATE STATUS CREATEDAT IMAGE PORTS NETWORKS RUNNINGFOR SIZE COMMAND PROJECT_NAME PROJECT_SERVICE_NAME; do
-                CLOUD_SERVICE_NAME="${PROJECT_NAME}::${PROJECT_SERVICE_NAME}"
+                CLOUD_SERVICE_NAME="${PROJECT_NAME}@${PROJECT_SERVICE_NAME}"
                 if [ -n "${CLOUD_SERVICE_NAME%% }" ]; then
                     message=$(printf '{"containerId":"%s","containerName":"%s","state":"%s","containerStatus":"%s","createdAt":"%s","image":"%s","ports":"%s","networks":"%s","runningFor":"%s","filesystem":"%s","command":%s,"projectName":"%s","serviceName":"%s"}' "${ID%% }" "${NAME%% }" "${STATE%% }" "${STATUS%% }" "${CREATEDAT%% }" "${IMAGE%% }" "${PORTS%% }" "${NETWORKS%% }" "${RUNNINGFOR%% }" "${SIZE%% }" "${COMMAND%% }" "${PROJECT_NAME}" "${PROJECT_SERVICE_NAME}")
-                    # FIXME: Change topic once tedge supports a service specific measurement topic
-                    # so that the user does not need to know that the service name is prefixed with the "{device.id}_"
-                    publish "c8y/inventory/managedObjects/update/${DEVICE_ID}_${CLOUD_SERVICE_NAME}" "$message"
+                    publish_retain "$TOPIC_PREFIX/service/$CLOUD_SERVICE_NAME/twin/container" "$message"
                 fi
             done
         fi
@@ -522,12 +510,9 @@ check_telemetry() {
             "$CONTAINER_CLI" stats --all --no-stream --format "{{.Name}}\t{{.CPUPerc}}\t{{.MemPerc}}\t{{.NetIO}}" $(echo "$CONTAINERS") | while IFS=$TAB read -r NAME CPU_PERC MEM_PERC NET_IO; do
                 NET_IO=$(echo "$NET_IO" | sed 's/[^0-9.].*//g')
 
-                # FIXME: Use tedge/measurements/{} topic once it can be controlled to not create a child device, but instead a child service
-                TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S%z")
-                message=$(printf '{"externalSource":{"externalId":"%s","type":"c8y_Serial"},"container":{"cpu":{"value":%s},"memory":{"value":%s},"netio":{"value":%s}},"time":"%s","type":"ThinEdgeMeasurement"}' "${DEVICE_ID}_${NAME}" "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}" "${TIMESTAMP}")
-                publish "c8y/measurement/measurements/create" "$message"
-                # message=$(printf '{"container": {"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
-                # publish "tedge/measurements/${DEVICE_ID}_${NAME}" "$message"
+                # Publish service metrics
+                message=$(printf '{"container":{"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
+                publish "$TOPIC_PREFIX/service/$NAME/m/resource_usage" "$message"
             done
         else
             debug "No containers found, therefore no metrics to collect"
@@ -541,15 +526,12 @@ check_telemetry() {
             # shellcheck disable=SC2046,SC2116
             "$CONTAINER_CLI" stats --all --no-stream --format "{{.Name}}\t{{.CPUPerc}}\t{{.MemPerc}}\t{{.NetIO}}" $(echo "$CONTAINERS") | while IFS=$TAB read -r NAME CPU_PERC MEM_PERC NET_IO; do
                 # lookup compose project and service name
-                CLOUD_SERVICE_NAME=$("$CONTAINER_CLI" ps -a --format "{{.Label \"com.docker.compose.project\" }}::{{.Label \"com.docker.compose.service\" }}" --filter "name=$NAME")
+                CLOUD_SERVICE_NAME=$("$CONTAINER_CLI" ps -a --format "{{.Label \"com.docker.compose.project\" }}@{{.Label \"com.docker.compose.service\" }}" --filter "name=$NAME")
                 NET_IO=$(echo "$NET_IO" | sed 's/[^0-9.].*//g')
 
-                # FIXME: Use tedge/measurements/{} topic once it can be controlled to not create a child device, but instead a child service
-                TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S%z")
-                message=$(printf '{"externalSource":{"externalId":"%s","type":"c8y_Serial"},"container":{"cpu":{"value":%s},"memory":{"value":%s},"netio":{"value":%s}},"time":"%s","type":"ThinEdgeMeasurement"}' "${DEVICE_ID}_${CLOUD_SERVICE_NAME}" "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}" "${TIMESTAMP}")
-                publish "c8y/measurement/measurements/create" "$message"
-                # message=$(printf '{"container": {"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
-                # publish "tedge/measurements/${DEVICE_ID}_${CLOUD_SERVICE_NAME}" "$message"
+                # Publish service metrics
+                message=$(printf '{"container":{"cpu":%s,"memory":%s,"netio":%s}}' "${CPU_PERC%%%*}" "${MEM_PERC%%%*}" "${NET_IO}")
+                publish "$TOPIC_PREFIX/service/$CLOUD_SERVICE_NAME/m/resource_usage" "$message"
             done
         else
             debug "No container-groups found, therefore no metrics to collect"

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tedge-container-plugin-ui",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "UI for the tedge-container-plugin to monitor installed containers and container groups.",
   "scripts": {
     "start": "c8ycli server -u https://mbay.eu-latest.cumulocity.com --shell devicemanagement",

--- a/ui/src/shared/container-service.ts
+++ b/ui/src/shared/container-service.ts
@@ -39,24 +39,25 @@ export class ContainerService {
     console.log(
       'Stopping Container' +
         container.containerId +
-        ', unfortnunatley it is not implementet yet'
+        ', unfortunately it is not implemented yet'
     );
   }
 
   private managedObjectToContainer(mo: IManagedObject): Container {
+    const container = mo.container;
     return {
       id: mo.id,
       name: mo.name,
-      containerId: mo.containerId,
-      ports: mo.ports,
-      command: mo.command,
-      networks: mo.networks,
-      filesystem: mo.filesystem,
-      image: mo.image,
-      runningFor: mo.runningFor,
-      state: mo.state,
-      status: mo.status,
-      project: mo.projectName,
+      containerId: container.containerId,
+      ports: container.ports,
+      command: container.command,
+      networks: container.networks,
+      filesystem: container.filesystem,
+      image: container.image,
+      runningFor: container.runningFor,
+      state: container.state,
+      status: container.status,
+      project: container.projectName,
       lastUpdated: mo.lastUpdated,
     };
   }


### PR DESCRIPTION
Switch to use the new thin-edge.io MQTT api (e.g. `te/` topics instead of the `tedge/` topics, see [docs](https://thin-edge.github.io/thin-edge.io/next/references/mqtt-api/) for details).

Warning this is a breaking change and will requires thin-edge.io >= 0.13.0 (or the latest in the main branch, e.g. >=0.12.1~528+ge11b64f)

* Publish container measurements using the type `resource_usage` (previously it was the default type `ThinEdgeMeasurement`
* Container metrics (c8y inventory data) is published to new `/twin/container` topic, which is then published to the Cumulocity device managed object under the `container` fragment
* Publish service health status to new tedge topic `te/device/main/service/<container_id>/...` 
* Changed container names to use the `@` separator instead of `::` (e.g. `alpine-s6::mosquitto` -> `alpine-s6@mosquitto`)