### PR TITLE
fix(container-group): fail if no docker-compose compatible cli is found

### DIFF
--- a/src/container-group
+++ b/src/container-group
@@ -62,6 +62,9 @@ if [ -z "$COMPOSE_CLI" ]; then
         COMPOSE_CLI="docker-compose"
     elif command -v "podman-compose" >/dev/null 2>&1; then
         COMPOSE_CLI="podman-compose"
+    else
+        log "No docker-compose compatible binary found. container-group software types will not be supported"
+        exit "$EXIT_USAGE"
     fi
 fi
 


### PR DESCRIPTION
The `container-group` software management plugin type will be disabled if a docker-compose compatible binary is not found (e.g. either docker-compose or podman-compose).

This allows users to still install tedge-container-plugin even if they don't have docker-compose installed and can still manage single containers using the `docker` cli (or equivalent).