### PR TITLE
fix(container-group): fix the service type when publishing the down status

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -83,7 +83,7 @@ The following properties are stored on the service managed object.
     "serviceName": "tedge",
     "state": "running",
   },
-  "name": "tedge-device::tedge",
+  "name": "tedge-device@tedge",
   "serviceType": "container-group",
   "status": "up",
   "type": "c8y_Service",

--- a/src/container-group
+++ b/src/container-group
@@ -202,8 +202,8 @@ case "$COMMAND" in
         # TODO: service monitoring does not support deleting a service
         # so at least mark it as uninstalled
         if command -V tedge >/dev/null 2>&1; then
-            for item in $(docker ps -a --filter "label=com.docker.compose.project=$MODULE_NAME" --format "{{.Label \"com.docker.compose.project\" }}::{{.Label \"com.docker.compose.service\" }}"); do
-                if [ "$item" != "::" ]; then
+            for item in $(docker ps -a --filter "label=com.docker.compose.project=$MODULE_NAME" --format "{{.Label \"com.docker.compose.project\" }}@{{.Label \"com.docker.compose.service\" }}"); do
+                if [ "$item" != "@" ]; then
                     log "Updating health endpoint status to uninstalled. service=$item"
                     MESSAGE="$(printf '{"status":"uninstalled","type":"%s"}' "${GROUP_SERVICE_TYPE:-"container-group"}" )"
                     publish_health "$item" "$MESSAGE" ||:

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -23,11 +23,13 @@ Install container-group package
     ${operation}=    Cumulocity.Execute Shell Command    wget -O- nginx:80
     Operation Should Be SUCCESSFUL    ${operation}
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    Welcome to nginx
+    Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    status=up
 
 Uninstall container-group
     ${operation}=     Cumulocity.Uninstall Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
     Operation Should Be SUCCESSFUL    ${operation}
     Device Should Not Have Installed Software    nginx
+    Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    status=uninstalled
 
 Install container package
     ${operation}=    Cumulocity.Install Software    {"name": "webserver", "version": "httpd:2.4", "softwareType": "container"}


### PR DESCRIPTION
Fix a problem with the container-group service status where the service name used to publish the `uninstalled` status was using `::` instead of `@` as the compose project/service separator.

The up status was already using the `@` separator.

**Before**

name: `myproject::nginx`

**After**

name: `myproject@nginx`