### PR TITLE
fix(container-group): ignore stderr when checking file type as stderr can be spammed

### DIFF
--- a/src/container-group
+++ b/src/container-group
@@ -182,7 +182,7 @@ case "$COMMAND" in
         # Note: alpine does not have "file" installed out of the box
         FILE_TYPE="unknown"
         if command -v file >/dev/null 2>&1; then
-            FILE_TYPE=$(file -db --mime-type "$FILE")
+            FILE_TYPE=$(file -db --mime-type "$FILE" 2>/dev/null)
         elif unzip -t "$FILE" >/dev/null 2>&1; then
             FILE_TYPE="application/zip"
         elif tar tf "$FILE" >/dev/null 2>&1; then


### PR DESCRIPTION
Fix a minor bug where checking the container-group file type (using `file`) would generated large stderr output, now the stderr is ignored when detecting the file type.