### PR TITLE
fix(ui): display container and container-groups tabs when either type is present

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tedge-container-plugin-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tedge-container-plugin-ui",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "Apache 2.0",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tedge-container-plugin-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "UI for the tedge-container-plugin to monitor installed containers and container groups.",
   "scripts": {
     "start": "c8ycli server -u $C8Y_URL --shell devicemanagement",

--- a/ui/src/shared/container.guard.ts
+++ b/ui/src/shared/container.guard.ts
@@ -12,7 +12,7 @@ export class ContainerGuard implements CanActivate {
     return this.inventoryService
       .childAdditionsList(
         { id },
-        { query: `serviceType eq container`, pageSize: 1 }
+        { query: `serviceType eq 'container' or serviceType eq 'container-group'`, pageSize: 1 }
       )
       .then(result => !!result?.data?.length);
   }


### PR DESCRIPTION
Previously the "container" and "container-group" tabs were only appearing if there was at least 1 "container" service deployed, and it would not display if there were only container-groups deployed.

Now having at least 1 container or 1 container-group will activate both of the tabs.