### PR TITLE
ci: fix warnings in test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,6 +67,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.17.0'
+          cache: false
       - name: Install dependencies
         run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
       - name: Build package (for testing)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,9 +59,7 @@ jobs:
           cache-dependency-path: |
             tests/requirements.txt
 
-      - uses: extractions/setup-just@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: taiki-e/install-action@just
 
       #
       # Build


### PR DESCRIPTION
Fix minor warnings in the test workflow:
* install just via `taiki-e/install-action@just` as it does not use the now deprecated nodejs 16.x
* Disable cache when installing golang