### PR TITLE
test: check monitor status after restarting mosquitto

### DIFF
--- a/src/monitor/tedge-container-monitor
+++ b/src/monitor/tedge-container-monitor
@@ -324,13 +324,15 @@ listen() {
     info "Subscribing to health-check messages"
     # Subscribe to the health-check topic, and just pass the topic to
     # this same script (to do a single on-demand health check for the given service)
+    # Note: https://github.com/thin-edge/tedge-container-plugin/issues/37
+    # Don't publish a service down message as if mosquitto is restarted, then the
+    # service down message (via the LWT) will be published, the mosquitto_sub will reconnect
+    # but then no new service up message will be published.
+    # 
     mosquitto_sub \
         --id "mosquitto_sub_${SERVICE_NAME}" \
         -h "$MQTT_HOST" \
         -p "$MQTT_PORT" \
-        --will-topic "$TOPIC_PREFIX/service/${SERVICE_NAME}/status/health" \
-        --will-payload "{\"status\":\"down\"}" \
-        --will-retain \
         -t "$TOPIC_PREFIX/service/+/cmd/health/check" \
         -F '%t' | while read -r topic; do
             name=$(echo "$topic" | cut -d/ -f 5)

--- a/tests/telemetry-main.robot
+++ b/tests/telemetry-main.robot
@@ -10,6 +10,14 @@ Suite Setup    Set Main Device
 Service status
     Cumulocity.Should Have Services    name=tedge-container-monitor      service_type=service    status=up    timeout=90
 
+    # Restarting mosquitto should not cause the service to be shown as "down"
+    # https://github.com/thin-edge/tedge-container-plugin/issues/37
+    Cumulocity.Execute Shell Command    sudo systemctl stop mosquitto
+    Sleep    2s    reason=Wait before starting mosquitto
+    Cumulocity.Execute Shell Command    sudo systemctl start mosquitto
+    Sleep    5s    reason=Give time for server to process any status changes to prevent checking too early
+    Cumulocity.Should Have Services    name=tedge-container-monitor      service_type=service    status=up
+
 Sends measurements
     Skip    TODO
     ${date_from}=    Get Test Start Time


### PR DESCRIPTION
Resolves https://github.com/thin-edge/tedge-container-plugin/issues/37

The container monitor service would remain in the "down" status if the connection to mosquitto would be interrupted for any reason (e.g. if mosquitto is restarted).

Now, the LWT is not used to publish the service "down" message as mosquitto_sub does not offer a way to published a message on reconnection.