### PR TITLE
ci: use setup-node to install specific nodejs version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,10 @@ jobs:
           go-version: '>=1.17.0'
           cache: false
       - run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
-        name: Install dependencies      
+        name: Install dependencies
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
       - name: Install node.js dependencies
         run: | 
               cd ./ui


### PR DESCRIPTION
Avoid problems when using the default globally installed nodejs version on the runner image. Use the setup-node to control the nodejs version instead.