### PR TITLE
fix(packaging): remove executable permission bits from systemd service definition

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -49,7 +49,7 @@ contents:
   - src: ./src/monitor/services/systemd/tedge-container-monitor.service
     dst: /usr/lib/systemd/system/tedge-container-monitor.service
     file_info:
-      mode: 0755
+      mode: 0644
       owner: tedge
       group: tedge
 


### PR DESCRIPTION
Systemd service definitions should not be marked as executable as unit files are only configuration.

Otherwise systemd shows a warning when installing the service:

```
Synchronizing state of tedge-container-monitor.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable tedge-container-monitor
Configuration file /lib/systemd/system/tedge-container-monitor.service is marked executable. Please remove executable permission bits. Proceeding anyway.
```