### PR TITLE
fix: include check for container fragment to reduce false positives

### DIFF
--- a/ui/src/shared/container.guard.ts
+++ b/ui/src/shared/container.guard.ts
@@ -12,7 +12,7 @@ export class ContainerGuard implements CanActivate {
     return this.inventoryService
       .childAdditionsList(
         { id },
-        { query: `serviceType eq 'container' or serviceType eq 'container-group'`, pageSize: 1 }
+        { query: `(serviceType eq 'container' or serviceType eq 'container-group') and has(container)`, pageSize: 1 }
       )
       .then(result => !!result?.data?.length);
   }


### PR DESCRIPTION
Prevent a false positive against the kedge-agent (for thick edge), where it registers the services with the serviceType `container` (the same as used by tedge-container-plugin).

Resolves #51.