### PR TITLE
fix: handling of custom DOCKER_HOST settings

### DIFF
--- a/src/container
+++ b/src/container
@@ -53,8 +53,12 @@ fi
 
 if [ -n "$FOUND_FILE" ]; then
     log "Loading setting file: $SETTINGS_FILE"
+    # Note: automatically export sourced variables to the environment
+    # as cli commands need to react to variables such as: DOCKER_HOST
+    set -a
     # shellcheck disable=SC1091,SC1090
     . "$SETTINGS_FILE"
+    set +a
 fi
 
 # Detect which container cli is available

--- a/src/container-group
+++ b/src/container-group
@@ -49,8 +49,12 @@ fi
 
 if [ -n "$FOUND_FILE" ]; then
     log "Loading setting file: $SETTINGS_FILE"
+    # Note: automatically export sourced variables to the environment
+    # as cli commands need to react to variables such as: DOCKER_HOST
+    set -a
     # shellcheck disable=SC1091,SC1090
     . "$SETTINGS_FILE"
+    set +a
 fi
 
 # Detect which container cli is available

--- a/src/monitor/tedge-container-monitor
+++ b/src/monitor/tedge-container-monitor
@@ -106,8 +106,10 @@ load_settings() {
 
     if [ -n "$FOUND_FILE" ]; then
         debug "Reloading setting file: $SETTINGS_FILE"
+        set -a
         # shellcheck disable=SC1091,SC1090
         . "$SETTINGS_FILE"
+        set +a
 
         # Convert log level before using any of the log helpers!
         LOG_LEVEL=$(convert_loglevel "$LOG_LEVEL")


### PR DESCRIPTION
When dot sourcing the tedge-container-plugin configuration file, `/etc/tedge-container-plugin/env`, ensure that all variables are also exported as environment variables so that the container cli applications can read the settings. This is especially important when controlling the engine socket location via `DOCKER_HOST`.

Previously, the `DOCKER_HOST` variable was not being exposed meaning that a custom socket path could not be used.