### PR TITLE
feat: avoid using absolute paths when calling tedge-container-monitor

### DIFF
--- a/src/container
+++ b/src/container
@@ -217,11 +217,11 @@ case "$COMMAND" in
             $CONTAINER_RUN_OPTIONS \
             "${MODULE_VERSION}"
 
-        if command -v /usr/bin/tedge-container-monitor >/dev/null 2>&1; then
+        if command -v tedge-container-monitor >/dev/null 2>&1; then
             # Wait before checking the first status
             sleep 1
             log "Trying to update container health status for $MODULE_NAME"
-            /usr/bin/tedge-container-monitor "$MODULE_NAME" ||:
+            tedge-container-monitor "$MODULE_NAME" ||:
         fi
 
         ;;

--- a/src/container-group
+++ b/src/container-group
@@ -280,11 +280,11 @@ case "$COMMAND" in
             log "Succesfully deployed project"
         fi
 
-        if command -v /usr/bin/tedge-container-monitor >/dev/null 2>&1; then
+        if command -v tedge-container-monitor >/dev/null 2>&1; then
             # Wait before checking the first status
             sleep 1
             log "Trying to update container health status for $MODULE_NAME"
-            /usr/bin/tedge-container-monitor "$MODULE_NAME" ||:
+            tedge-container-monitor "$MODULE_NAME" ||:
         fi
 
         exit "$EXIT_CODE"


### PR DESCRIPTION
Don't use absolte paths to allow users to also override the `tedge-container-monitor` command if necessary