### PR TITLE
feat: add new container-cli command

### DIFF
--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -38,6 +38,13 @@ contents:
       owner: tedge
       group: tedge
 
+  - src: ./src/container-cli
+    dst: /usr/bin/container-cli
+    file_info:
+      mode: 0755
+      owner: root
+      group: root
+
   - src: ./src/monitor/env
     dst: /etc/tedge-container-plugin/env
     type: config|noreplace

--- a/src/container-cli
+++ b/src/container-cli
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+CONTAINER_CLI=
+CONTAINER_CLI_OPTIONS="docker podman nerdctl"
+SETTINGS_FILE=/etc/tedge-container-plugin/env
+
+# Only read the file if it has the correct permissions, to prevent people from editing it
+# and side-loading functions
+SETTINGS_FILE=/etc/tedge-container-plugin/env
+FOUND_FILE=
+if [ -f "$SETTINGS_FILE" ]; then
+    FOUND_FILE=$(find "$SETTINGS_FILE" -perm 644 | head -1)
+fi
+
+if [ -n "$FOUND_FILE" ]; then
+    echo "Loading setting file: $SETTINGS_FILE" >&2
+    # Note: automatically export sourced variables to the environment
+    # as cli commands need to react to variables such as: DOCKER_HOST
+    set -a
+    # shellcheck disable=SC1091,SC1090
+    . "$SETTINGS_FILE"
+    set +a
+fi
+
+# Detect which container cli is available
+if [ -z "$CONTAINER_CLI" ]; then
+    for cli in $CONTAINER_CLI_OPTIONS; do
+        if command -v "$cli" >/dev/null 2>&1; then
+            echo "Using $cli as the container cli" >&2
+            CONTAINER_CLI="$cli"
+            break
+        fi
+    done
+fi
+
+# script is being sourced
+"$CONTAINER_CLI" "$@"


### PR DESCRIPTION
The new command `container-cli` allows users to call the container commands (and add it to the sudoers rule) without having to know the underlying container cli