### PR TITLE
fix(podman): strip incompatible cli arguments from podman-compose down command

### DIFF
--- a/pkg/container/compose.go
+++ b/pkg/container/compose.go
@@ -34,6 +34,24 @@ func prepareComposeCommand(commandArgs ...string) (command string, args []string
 	if err != nil {
 		return
 	}
+
+	// Normalized differences between the commands
+	if command == "podman-compose" && len(commandArgs) > 0 && commandArgs[0] == "down" {
+		// Note: podman-compose down does not support "--remove-orphans" argument, so strip it out
+		commandArgs = filter(commandArgs, func(s string) bool {
+			return s != "--remove-orphans"
+		})
+	}
+
 	args = append(args, commandArgs...)
 	return command, args, nil
+}
+
+func filter(ss []string, test func(string) bool) (ret []string) {
+	for _, s := range ss {
+		if test(s) {
+			ret = append(ret, s)
+		}
+	}
+	return
 }

--- a/test-images/debian-systemd-docker-cli/Dockerfile
+++ b/test-images/debian-systemd-docker-cli/Dockerfile
@@ -4,8 +4,14 @@ ARG TARGETPLATFORM
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         # Install with all recommended packages as this is simplier to maintain
-        podman \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" -y --no-install-recommends \
+        && install -m 0755 -d /etc/apt/keyrings \
+        && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
+        && chmod a+r /etc/apt/keyrings/docker.asc \    
+        && echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+        && apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confnew" -y --no-install-recommends \
         # Installing docker-ce at build time fails.
         # See https://github.com/docker/cli/issues/4807 for details
         # docker-ce \
@@ -28,9 +34,7 @@ RUN case ${TARGETPLATFORM} in \
         "linux/arm/v7")  PKG_ARCH=linux_armv7  ;; \
         *) echo "Unsupported target platform: TARGETPLATFORM=$TARGETPLATFORM"; exit 1 ;; \
     esac \
-    # FIXME: Replace once project is merged back with tedge-container-plugin
-    # && apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" --allow-downgrades -y /tmp/*${PKG_ARCH}*.deb \
-    && dpkg -i --force-overwrite /tmp/*${PKG_ARCH}*.deb \
+    && apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" --allow-downgrades -y /tmp/*${PKG_ARCH}*.deb \
     && mkdir -p /opt/packages \
     && cp /tmp/*${PKG_ARCH}*.deb /opt/packages/ \
     && rm -f /tmp/*.deb

--- a/test-images/debian-systemd-podman-cli/Dockerfile
+++ b/test-images/debian-systemd-podman-cli/Dockerfile
@@ -1,13 +1,7 @@
 FROM ghcr.io/thin-edge/tedge-demo-main-systemd:latest
 ARG TARGETPLATFORM
 
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        # Install with all recommended packages as this is simplier to maintain
-        podman \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" -y --no-install-recommends \
-        podman-compose \
-    && tedge config unset c8y.proxy.client.host \
+RUN tedge config unset c8y.proxy.client.host \
     && tedge config unset mqtt.client.host \
     && tedge config unset http.client.host
 
@@ -23,9 +17,7 @@ RUN case ${TARGETPLATFORM} in \
         "linux/arm/v7")  PKG_ARCH=linux_armv7  ;; \
         *) echo "Unsupported target platform: TARGETPLATFORM=$TARGETPLATFORM"; exit 1 ;; \
     esac \
-    # FIXME: Replace once project is merged back with tedge-container-plugin
-    # && apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" --allow-downgrades -y /tmp/*${PKG_ARCH}*.deb \
-    && dpkg -i --force-overwrite /tmp/*${PKG_ARCH}*.deb \
+    && apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" --allow-downgrades -y /tmp/*${PKG_ARCH}*.deb \
     && mkdir -p /opt/packages \
     && cp /tmp/*${PKG_ARCH}*.deb /opt/packages/ \
     && rm -f /tmp/*.deb

--- a/tests/data/apps/app1/Dockerfile
+++ b/tests/data/apps/app1/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx
+FROM docker.io/nginx
 COPY static /usr/share/nginx/html

--- a/tests/data/apps/app2/Dockerfile
+++ b/tests/data/apps/app2/Dockerfile
@@ -1,2 +1,2 @@
-FROM nginx
+FROM docker.io/nginx
 COPY static /usr/share/nginx/html

--- a/tests/data/apps/app3/Dockerfile
+++ b/tests/data/apps/app3/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.18
+FROM docker.io/alpine:3.18
 ENTRYPOINT [ "/bin/sleep", "infinity" ]

--- a/tests/data/docker-compose.nginx.yaml
+++ b/tests/data/docker-compose.nginx.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   nginx:
-    image: nginx
+    image: docker.io/nginx
     hostname: nginx
     networks:
       - tedge

--- a/tests/installation.robot
+++ b/tests/installation.robot
@@ -26,10 +26,11 @@ Test Setup
     Set Suite Variable    $DEVICE_SN
     Cumulocity.External Identity Should Exist    ${DEVICE_SN}
 
-    # Install older version
+    # Remove an previously installed versions (for a clean install)
     DeviceLibrary.Execute Command    apt-get remove -y tedge-container-plugin-ng && apt-get purge -y tedge-container-plugin-ng
-    DeviceLibrary.Execute Command    apt-get remove -y tedge-container-plugin && apt-get purge -y tedge-container-plugin     ignore_exit_code=${True}
+    DeviceLibrary.Execute Command    apt-get remove -y tedge-container-plugin && apt-get purge -y tedge-container-plugin && rm -rf /etc/tedge-container-plugin     ignore_exit_code=${True}
 
+    # Install older version
     DeviceLibrary.Execute Command   apt-get update && apt-get install -y tedge-container-plugin
     Cumulocity.Should Have Services    name=tedge-container-monitor    service_type=service    min_count=1    max_count=1    timeout=60
 

--- a/tests/installation.robot
+++ b/tests/installation.robot
@@ -9,7 +9,7 @@ Test Teardown    Collect Logs
 *** Test Cases ***
 
 Update to tedge-container-plugin-ng
-    DeviceLibrary.Execute Command   cmd=apt-get install -y -o Dpkg::Options::="--force-confdef" /opt/packages/*.deb
+    DeviceLibrary.Execute Command   cmd=apt-get install -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" /opt/packages/*.deb
     Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
     Cumulocity.Should Have Services    name=tedge-container-monitor    service_type=service    min_count=0    max_count=0    timeout=30
 

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -32,10 +32,11 @@ Install/uninstall container-group package
     Device Should Not Have Installed Software    nginx
     Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    min_count=0    max_count=0
 
-Install container-group with multiple files
-    [Template]    Install container-group file
-    app1    1.0.1    app1    ${CURDIR}/data/apps/app1.tar.gz
-    app2    1.2.3    app2    ${CURDIR}/data/apps/app2.zip
+Install container-group with multiple files - app1
+    Install container-group file    app1    1.0.1    app1    ${CURDIR}/data/apps/app1.tar.gz
+
+Install container-group with multiple files - app2
+    Install container-group file    app2    1.2.3    app2    ${CURDIR}/data/apps/app2.zip
 
 Install/uninstall container package
     ${operation}=    Cumulocity.Install Software    {"name": "webserver", "version": "httpd:2.4", "softwareType": "container"}

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -42,7 +42,7 @@ Install/uninstall container package
     ${operation}=    Cumulocity.Install Software    {"name": "webserver", "version": "httpd:2.4", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Device Should Have Installed Software    {"name": "webserver", "version": "httpd:2.4", "softwareType": "container"}
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge busybox wget -O- webserver:80;
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/busybox wget -O- webserver:80;
     Operation Should Be SUCCESSFUL    ${operation}
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    It works!
     Cumulocity.Should Have Services    name=webserver    service_type=container    status=up
@@ -73,7 +73,7 @@ Manual container creation/deletion
     ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:; sudo tedge-container engine docker run -d --network tedge --name manualapp1 httpd:2.4
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
 
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge busybox wget -O- manualapp1:80;
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/busybox wget -O- manualapp1:80;
     Operation Should Be SUCCESSFUL    ${operation}
 
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    It works!
@@ -138,7 +138,7 @@ Install container-group file
     ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=300
     Device Should Have Installed Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group"}
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge busybox wget -O- ${service_name}:80
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/busybox wget -O- ${service_name}:80
     Operation Should Be SUCCESSFUL    ${operation}
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    My Custom Web Application
     Cumulocity.Should Have Services    name=${package_name}@${service_name}    service_type=container-group    status=up


### PR DESCRIPTION
podman-compose does not support `podman-compose down --remove-orphans`, so the command is normalized and the argument is removed when preparing the compose cli command.

The system tests were also updated to use fully qualified image names so that podman can resolve the container images.