### PR TITLE
feat: support golang 1.22 (for Yocto kirkstone lts-mixin)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thin-edge/tedge-container-plugin
 
-go 1.23.2
+go 1.22.0
 
 require (
 	github.com/codeclysm/extract/v4 v4.0.0


### PR DESCRIPTION
Allow building with golang 1.22 which is the current supported version in the Yocto kirkstone lts-mixin.