### PR TITLE
fix(container): container file image name detection

### DIFF
--- a/cli/container/install.go
+++ b/cli/container/install.go
@@ -110,6 +110,10 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if imageRef != c.ModuleVersion {
+		slog.Warn("Detected image reference does not match the module-version.", "imageRef", imageRef, "version", c.ModuleVersion)
+	}
+
 	// Create shared network
 	if err := cli.CreateSharedNetwork(ctx, commonNetwork); err != nil {
 		return err

--- a/cli/container/install.go
+++ b/cli/container/install.go
@@ -71,6 +71,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
+		defer file.Close()
 
 		imageResp, err := cli.Client.ImageLoad(ctx, file, true)
 		if err != nil {


### PR DESCRIPTION
Fix the image name detection used when loading the container image from file.

The main bug was that trailing `\n` characters were not being stripped from the name.

Now a more robust parsing method is supported where it can also detect if multiple images are detected within the image. The first found image will be used as the image ref.