### PR TITLE
feat(config): add data_dir config setting

### DIFF
--- a/cli/container_group/install.go
+++ b/cli/container_group/install.go
@@ -61,8 +61,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	// Run docker compose down before up
 	// TODO: Move to settings file
 	downFirst := false
-	baseDir := "/var/tedge-container-plugin/compose"
-	workingDir := filepath.Join(baseDir, projectName)
+	workingDir := filepath.Join(c.CommandContext.PersistentDir(true), "compose", projectName)
 
 	// Stop project
 	if downFirst && utils.PathExists(workingDir) {

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -4,6 +4,10 @@ log_level = "info"
 # Service name used to show the status of the service
 service_name = "tedge-container-plugin"
 
+# Data directory used to store state such as docker compose project files
+# The first writable directory will be used
+data_dir = ["/var/tedge-container-plugin", "/data/tedge-container-plugin"]
+
 # Remove the legacy tedge-container-monitor service
 delete_legacy = true
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 )
@@ -25,4 +26,21 @@ func CopyFile(src string, dst string) error {
 func CommandExists(cmd string) bool {
 	_, err := exec.LookPath(cmd)
 	return err == nil
+}
+
+// Check if a directory is writable.
+// It tries to create a dummy file in the directory to verify
+func IsDirWritable(d string, perm fs.FileMode) (bool, error) {
+	dirErr := os.MkdirAll(d, 0755)
+	if dirErr != nil {
+		return false, dirErr
+	}
+
+	file, err := os.CreateTemp(d, ".write-test")
+	if err != nil {
+		return false, err
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+	return true, nil
 }


### PR DESCRIPTION
Support changing the data directory used when installing container-groups. On read-only root filesystems, this value needs to be configurable otherwise the container-group feature does not work.