### PR TITLE
feat: include podman-remote cli detection

### DIFF
--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -11,6 +11,7 @@ func detectDocker() (command string, args []string, err error) {
 	composeBackends := [][]string{
 		{"docker"},
 		{"podman"},
+		{"podman-remote"},
 	}
 
 	for _, backend := range composeBackends {


### PR DESCRIPTION
Support detecting `podman-remote` cli when running `tedge-container engine docker`