### PR TITLE
fix: persistent directory handling in sm-plugins

### DIFF
--- a/cli/container_group/install.go
+++ b/cli/container_group/install.go
@@ -61,10 +61,14 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	// Run docker compose down before up
 	// TODO: Move to settings file
 	downFirst := false
-	workingDir := filepath.Join(c.CommandContext.PersistentDir(true), "compose", projectName)
+	persistentDir, err := c.CommandContext.PersistentDir(true)
+	if err != nil {
+		return err
+	}
+	workingDir := filepath.Join(persistentDir, "compose", projectName)
 
 	// Stop project
-	if downFirst && utils.PathExists(workingDir) {
+	if downFirst {
 		if err := cli.ComposeDown(ctx, stderr, projectName); err != nil {
 			slog.Warn("Compose down failed, but continuing anyway.", "err", err)
 		}

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -5,8 +5,8 @@ log_level = "info"
 service_name = "tedge-container-plugin"
 
 # Data directory used to store state such as docker compose project files
-# The first writable directory will be used
-data_dir = ["/var/tedge-container-plugin", "/data/tedge-container-plugin"]
+# The first writable directory will be used where the root directory exists
+data_dir = ["/data/tedge-container-plugin", "/var/tedge-container-plugin"]
 
 # Remove the legacy tedge-container-monitor service
 delete_legacy = true

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -28,7 +28,16 @@ func (c *Cli) OnInit() {
 	// Set shared config
 	viper.SetDefault("container.network", "tedge")
 	viper.SetDefault("delete_legacy", true)
-	viper.SetDefault("data_dir", []string{"/var/tedge-container-plugin", "/data/tedge-container-plugin"})
+	viper.SetDefault("data_dir", []string{"/data/tedge-container-plugin", "/var/tedge-container-plugin"})
+
+	// Default to the tedge plugins folder
+	if c.ConfigFile == "" {
+		configDir := os.Getenv("TEDGE_CONFIG_DIR")
+		if configDir == "" {
+			configDir = "/etc/tedge"
+		}
+		filepath.Join(configDir, "plugins", "tedge-container-plugin.toml")
+	}
 
 	if c.ConfigFile != "" && utils.PathExists(c.ConfigFile) {
 		// Use config file from the flag.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func PathExists(p string) bool {
@@ -43,4 +44,15 @@ func IsDirWritable(d string, perm fs.FileMode) (bool, error) {
 	defer os.Remove(file.Name())
 	defer file.Close()
 	return true, nil
+}
+
+func RootDir(p string) string {
+	for {
+		v1 := filepath.Dir(p)
+		v2 := filepath.Dir(v1)
+		if v1 == v2 {
+			return p
+		}
+		p = v1
+	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"testing"
+)
+
+func Test_RootDir(t *testing.T) {
+	test_cases := []struct {
+		Path     string
+		Expected string
+	}{
+		{
+			Path:     "/data/example/foo.txt",
+			Expected: "/data",
+		},
+		{
+			Path:     "/data/example",
+			Expected: "/data",
+		},
+		{
+			Path:     "/test",
+			Expected: "/test",
+		},
+		{
+			Path:     "/",
+			Expected: "/",
+		},
+		{
+			Path:     "",
+			Expected: "",
+		},
+	}
+	for _, c := range test_cases {
+
+		got := RootDir(c.Path)
+		if got != c.Expected {
+			t.Errorf("Invalid root dir. got=%v, wanted=%v", got, c.Expected)
+		}
+
+	}
+}

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -132,11 +132,17 @@ Suite Setup
     # Create common network for all containers
     ${operation}=    Cumulocity.Execute Shell Command    set -a; . /etc/tedge-container-plugin/env; docker network create tedge ||:
 
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir /data
+
 Install container-group file
     [Arguments]    ${package_name}    ${package_version}    ${service_name}    ${file}
     ${binary_url}=    Cumulocity.Create Inventory Binary    ${package_name}    container-group    file=${file}
     ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=300
+
+    DeviceLibrary.Directory Should Not Be Empty    /data/tedge-container-plugin/compose/${package_name}
+
     Device Should Have Installed Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group"}
     ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/busybox wget -O- ${service_name}:80
     Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
Fix an issue with the persistent directory selection where the plugin's configuration file was not being used when running the sm-plugins.

In addition, the persistent directory now follows the logic:
* Select first writable directory where the root diretory exists
* Set default configuration file to the TEDGE_CONFIG_DIR plugins folder