### PR TITLE
fix: parse podman-compose output to check for non-zero exit code

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,7 @@ func init() {
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Log level")
 	rootCmd.PersistentFlags().StringVarP(&cliConfig.ConfigFile, "config", "c", "", "Configuration file")
+	rootCmd.SilenceUsage = true
 
 	// viper.Bind
 	_ = viper.BindPFlag("log_level", rootCmd.PersistentFlags().Lookup("log-level"))

--- a/pkg/container/compose_test.go
+++ b/pkg/container/compose_test.go
@@ -1,0 +1,18 @@
+package container
+
+import "testing"
+
+func Test_Podman(t *testing.T) {
+	output := `
+podman-compose build
+['podman', '--version', '']
+using podman version: 4.3.1
+podman build -t app1_app1 -f ./Dockerfile .
+STEP 1/2: FROM nginx
+Error: creating build container: short-name "nginx" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
+exit code: 125
+`
+	if CheckPodmanComposeError(output) == nil {
+		t.Fail()
+	}
+}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -565,7 +565,7 @@ func (c *ContainerClient) ComposeUp(ctx context.Context, w io.Writer, projectNam
 	args = append(args, extraArgs...)
 	prog := exec.Command(command, args...)
 	prog.Dir = workingDir
-	out, err := prog.Output()
+	out, err := prog.CombinedOutput()
 	fmt.Fprintf(w, "%s", out)
 
 	if err != nil {
@@ -586,7 +586,9 @@ func CheckPodmanComposeError(b string) error {
 		_, value, ok := strings.Cut(line, "exit code: ")
 		if ok {
 			if i, err := strconv.ParseInt(strings.TrimSpace(value), 10, 32); err == nil {
-				return fmt.Errorf("command failed. exit_code=%v", i)
+				if i != 0 {
+					return fmt.Errorf("command failed. exit_code=%v", i)
+				}
 			}
 		}
 	}
@@ -625,7 +627,7 @@ func (c *ContainerClient) ComposeDown(ctx context.Context, w io.Writer, projectN
 		slog.Info("Stopping compose project.", "name", projectName, "dir", workingDir, "command", command, "args", strings.Join(args, " "))
 		prog := exec.Command(command, args...)
 		prog.Dir = workingDir
-		out, err := prog.Output()
+		out, err := prog.CombinedOutput()
 		fmt.Fprintf(w, "%s", out)
 
 		if err == nil {

--- a/tests/data/docker-compose.invalid.yaml
+++ b/tests/data/docker-compose.invalid.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  nginx:
+    image: docker.io/nginx
+    hostname: nginx
+    networks:
+      - tedge-invalid
+    ports:
+      - 8080:80

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -32,6 +32,13 @@ Install/uninstall container-group package
     Device Should Not Have Installed Software    nginx
     Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    min_count=0    max_count=0
 
+
+Install invalid container-group
+    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid.yaml
+    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be FAILED    ${operation}    timeout=60
+    Device Should Not Have Installed Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
+
 Install container-group with multiple files - app1
     Install container-group file    app1    1.0.1    app1    ${CURDIR}/data/apps/app1.tar.gz
 


### PR DESCRIPTION
Due to a limitation with podman-compose, parse the exit code from stderr and propogate it back.

Resolves https://github.com/thin-edge/tedge-container-plugin/issues/70