### PR TITLE
fix: error message when no container cli tool is found

### DIFF
--- a/pkg/container/docker.go
+++ b/pkg/container/docker.go
@@ -27,7 +27,7 @@ func detectDocker() (command string, args []string, err error) {
 		slog.Info("command failed.", "command", strings.Join(backend, " "), "output", output)
 	}
 
-	return "", nil, fmt.Errorf("compose cli not found")
+	return "", nil, fmt.Errorf("docker cli not found")
 }
 
 func prepareDockerCommand(commandArgs ...string) (command string, args []string, err error) {


### PR DESCRIPTION
Fixing minor error when no container cli (e.g. docker, podman or podman-remote) is found. Previously the error would return "compose cli not found" giving the wrong impression that it was looking for compose and not the container engine cli