### PR TITLE
feat(packaging): add s6-overlay service definitions to alpine package

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -122,6 +122,15 @@ nfpms:
           mode: 0644
           owner: tedge
           group: tedge
+        packager: deb
+
+      - src: ./packaging/services/systemd/tedge-container-plugin.service
+        dst: /usr/lib/systemd/system/tedge-container-plugin.service
+        file_info:
+          mode: 0644
+          owner: tedge
+          group: tedge
+        packager: rpm
 
       - src: ./packaging/services/init.d/service.init
         dst: /etc/init.d/tedge-container-plugin
@@ -129,6 +138,26 @@ nfpms:
           mode: 0644
           owner: tedge
           group: tedge
+        packager: deb
+
+      - src: ./packaging/services/init.d/service.init
+        dst: /etc/init.d/tedge-container-plugin
+        file_info:
+          mode: 0644
+          owner: tedge
+          group: tedge
+        packager: rpm
+
+      # s6-overlay services
+      - src: ./packaging/services/s6-overlay/tedge-container-plugin
+        dst: /etc/s6-overlay/s6-rc.d/tedge-container-plugin
+        packager: apk
+        type: tree
+
+      - src: ./packaging/services/s6-overlay/tedge-container-plugin-log
+        dst: /etc/s6-overlay/s6-rc.d/tedge-container-plugin-log
+        packager: apk
+        type: tree
 
       # Completions
       - src: ./output/completions.bash

--- a/packaging/services/s6-overlay/tedge-container-plugin-log/consumer-for
+++ b/packaging/services/s6-overlay/tedge-container-plugin-log/consumer-for
@@ -1,0 +1,1 @@
+tedge-container-plugin

--- a/packaging/services/s6-overlay/tedge-container-plugin-log/pipeline-name
+++ b/packaging/services/s6-overlay/tedge-container-plugin-log/pipeline-name
@@ -1,0 +1,1 @@
+tedge-container-plugin-pipeline

--- a/packaging/services/s6-overlay/tedge-container-plugin-log/run
+++ b/packaging/services/s6-overlay/tedge-container-plugin-log/run
@@ -1,0 +1,2 @@
+#!/command/execlineb -P
+s6-format-filter "\033[34m%1 |\033[0m %s" "tedge-container-plugin"

--- a/packaging/services/s6-overlay/tedge-container-plugin-log/type
+++ b/packaging/services/s6-overlay/tedge-container-plugin-log/type
@@ -1,0 +1,1 @@
+longrun

--- a/packaging/services/s6-overlay/tedge-container-plugin/producer-for
+++ b/packaging/services/s6-overlay/tedge-container-plugin/producer-for
@@ -1,0 +1,1 @@
+tedge-container-plugin-log

--- a/packaging/services/s6-overlay/tedge-container-plugin/run
+++ b/packaging/services/s6-overlay/tedge-container-plugin/run
@@ -1,0 +1,11 @@
+#!/command/with-contenv sh
+if [ "${SERVICE_TEDGE_CONTAINER_PLUGIN:-1}" -eq 0 ]; then
+    # Disable service and don't start again
+    # https://github.com/just-containers/s6-overlay/issues/394
+    s6-svc -O .
+    exit 0
+fi
+tedge init ||:
+
+exec 2>&1
+exec $COMMAND $COMMAND_ARGS

--- a/packaging/services/s6-overlay/tedge-container-plugin/type
+++ b/packaging/services/s6-overlay/tedge-container-plugin/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
Support for running the tedge-container-plugin service under s6-overlay service manager (for alpine packages only).

Note, the s6-overlay definitions were taken from the template files in the [tedge-services](https://github.com/thin-edge/tedge-services/tree/main/services/s6-overlay/templates) project.