### PR TITLE
feat: add commands to clone a container

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -107,6 +107,12 @@ nfpms:
         dst: /etc/tedge/sm-plugins/container-group
         type: symlink
 
+      # apk only (used for self updates)
+      - src: /usr/bin/tedge-container
+        dst: /etc/tedge/sm-plugins/self
+        type: symlink
+        packager: apk
+
       # Config
       - src: ./packaging/config.*
         dst: /etc/tedge-container-plugin/

--- a/cli/engine/cmd.go
+++ b/cli/engine/cmd.go
@@ -13,6 +13,7 @@ func NewCliCommand(cmdCli cli.Cli) *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewRunCommand(cmdCli),
+		NewContainerCloneCommand(cmdCli),
 	)
 	return cmd
 }

--- a/cli/engine/cmd.go
+++ b/cli/engine/cmd.go
@@ -13,7 +13,6 @@ func NewCliCommand(cmdCli cli.Cli) *cobra.Command {
 	}
 	cmd.AddCommand(
 		NewRunCommand(cmdCli),
-		NewContainerCloneCommand(cmdCli),
 	)
 	return cmd
 }

--- a/cli/engine/container_clone.go
+++ b/cli/engine/container_clone.go
@@ -1,0 +1,142 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package engine
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+	"github.com/thin-edge/tedge-container-plugin/pkg/container"
+	"github.com/thin-edge/tedge-container-plugin/pkg/utils"
+)
+
+type ContainerCloneCommand struct {
+	*cobra.Command
+
+	CommandContext cli.Cli
+
+	// Options
+	ForceUpdate    bool
+	Fork           bool
+	WaitForExit    bool
+	CheckForUpdate bool
+	ContainerID    string
+	Image          string
+	Duration       time.Duration
+	StopTimeout    time.Duration
+	AutoRemove     bool
+	AddHost        []string
+	Env            []string
+}
+
+// NewRunCommand create a new run command
+func NewContainerCloneCommand(ctx cli.Cli) *cobra.Command {
+	command := &ContainerCloneCommand{
+		CommandContext: ctx,
+	}
+	cmd := &cobra.Command{
+		Use:          "container-clone",
+		Short:        "Clone an existing container and replace the container image",
+		RunE:         command.RunE,
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringVar(&command.ContainerID, "container", "", "Container to clone. Either container id or name")
+	cmd.Flags().StringVar(&command.Image, "image", "", "Container image")
+	cmd.Flags().DurationVar(&command.Duration, "duration", 15*time.Second, "How long to wait for the clone container to be healthy")
+	cmd.Flags().DurationVar(&command.StopTimeout, "stop-timeout", 60*time.Second, "Timeout used whilst waiting for container to stop. Only used with --wait-for-exit")
+	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the closed container on exit")
+	cmd.Flags().StringSliceVar(&command.AddHost, "add-host", []string{}, "Add extra hosts to the container")
+	cmd.Flags().StringSliceVarP(&command.Env, "env", "e", []string{}, "Environment variables to add to the container")
+	cmd.Flags().BoolVar(&command.ForceUpdate, "force", false, "Force an update, disable the image comparison check")
+	cmd.Flags().BoolVar(&command.Fork, "fork", false, "Spawn a new container to do the update")
+	cmd.Flags().BoolVar(&command.WaitForExit, "wait-for-exit", false, "Wait for the container to stop/exit before updating")
+	cmd.Flags().BoolVar(&command.CheckForUpdate, "check", false, "Only check if an update is necessary, don't perform the update")
+
+	_ = cmd.MarkFlagRequired("container")
+	command.Command = cmd
+	return cmd
+}
+
+func (c *ContainerCloneCommand) RunE(cmd *cobra.Command, args []string) error {
+	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
+	containerCli, err := container.NewContainerClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if c.CheckForUpdate {
+		if c.ForceUpdate {
+			slog.Info("Forcing an update")
+			return nil
+		}
+		needsUpdate, _, err := containerCli.UpdateRequired(ctx, c.ContainerID, c.Image)
+		if err != nil {
+			return err
+		}
+
+		if needsUpdate {
+			slog.Info("Image needs updating")
+			return nil
+		}
+		return cli.ExitCodeError{
+			Code:   2,
+			Err:    fmt.Errorf("image does not need updating"),
+			Silent: true,
+		}
+	}
+
+	if c.Fork {
+		if !container.IsInsideContainer() {
+			return fmt.Errorf("can't fork from outside of a container")
+		}
+
+		entrypoint := make([]string, 0)
+
+		if utils.CommandExists("sudo") {
+			entrypoint = append(entrypoint, "sudo")
+		}
+		entrypoint = append(
+			entrypoint,
+			"tedge-container",
+			"engine",
+			"container-clone",
+			"--container",
+			c.ContainerID,
+			"--image",
+			c.Image,
+			"--wait-for-exit",
+			"stop-timeout", c.StopTimeout.String(),
+		)
+
+		if c.AutoRemove {
+			entrypoint = append(entrypoint, "--rm")
+		}
+
+		for _, v := range c.AddHost {
+			entrypoint = append(entrypoint, "--add-host", v)
+		}
+
+		for _, v := range c.Env {
+			entrypoint = append(entrypoint, "--env", v)
+		}
+
+		return containerCli.Fork(context.Background(), entrypoint, []string{})
+	}
+
+	return containerCli.CloneContainer(context.Background(), c.ContainerID, container.CloneOptions{
+		Image:        c.Image,
+		HealthyAfter: c.Duration,
+		WaitForExit:  c.WaitForExit,
+		StopTimeout:  c.StopTimeout,
+		AutoRemove:   c.AutoRemove,
+		Env:          c.Env,
+		ExtraHosts:   c.AddHost,
+	})
+}

--- a/cli/engine/container_clone.go
+++ b/cli/engine/container_clone.go
@@ -44,6 +44,7 @@ func NewContainerCloneCommand(ctx cli.Cli) *cobra.Command {
 		Short:        "Clone an existing container and replace the container image",
 		RunE:         command.RunE,
 		SilenceUsage: true,
+		Hidden:       true,
 	}
 	cmd.Flags().StringVar(&command.ContainerID, "container", "", "Container to clone. Either container id or name")
 	cmd.Flags().StringVar(&command.Image, "image", "", "Container image")

--- a/cli/engine/docker.go
+++ b/cli/engine/docker.go
@@ -48,5 +48,12 @@ func (c *DockerCommand) RunE(cmd *cobra.Command, args []string) error {
 	command.Stdout = cmd.OutOrStdout()
 	command.Stdin = cmd.InOrStdin()
 
-	return cli.SilentError(command.Run())
+	runErr := command.Run()
+	if runErr != nil {
+		return cli.ExitCodeError{
+			Err:    runErr,
+			Silent: true,
+		}
+	}
+	return nil
 }

--- a/cli/self/check.go
+++ b/cli/self/check.go
@@ -1,0 +1,94 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+type SoftwareModule struct {
+	Type    string         `json:"type,omitempty"`
+	Modules []SoftwareItem `json:"modules"`
+}
+
+type SoftwareItem struct {
+	Action  string `json:"action,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+
+type UpdateInfo struct {
+	ContainerName string `json:"containerName"`
+	Image         string `json:"image"`
+}
+
+var ExitYes = 0
+var ExitNo = 1
+var ExitError = 2
+
+func newUnexpectedError(err error) error {
+	return cli.ExitCodeError{
+		Err:  err,
+		Code: ExitError,
+	}
+}
+
+var SoftwareManagementType = "self"
+var SoftwareManagementActionInstall = "install"
+
+// NewCheckCommand represents the check command
+func NewCheckCommand(ctx cli.Cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Args:  cobra.ExactArgs(1),
+		Short: "Check if an update is required (not part of sm-plugin interface!)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+
+			updateList := make([]SoftwareModule, 0)
+			if err := json.Unmarshal([]byte(args[0]), &updateList); err != nil {
+				return newUnexpectedError(err)
+			}
+
+			includesSelfUpdate := false
+
+			match := UpdateInfo{}
+			for _, module := range updateList {
+				if module.Type == SoftwareManagementType {
+					for _, item := range module.Modules {
+						if item.Action == SoftwareManagementActionInstall {
+							match.ContainerName = item.Name
+							match.Image = item.Version
+							includesSelfUpdate = true
+							break
+						}
+					}
+					break
+				}
+			}
+
+			if !includesSelfUpdate {
+				return cli.ExitCodeError{
+					Code:   ExitNo,
+					Silent: true,
+				}
+			}
+
+			slog.Info("Update included a self update")
+			payload, err := json.Marshal(match)
+			if err != nil {
+				return newUnexpectedError(err)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), ":::begin-tedge:::\n%s\n:::end-tedge:::\n", payload)
+
+			// includes self update
+			return nil
+		},
+	}
+}

--- a/cli/self/cmd.go
+++ b/cli/self/cmd.go
@@ -1,0 +1,25 @@
+package self
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+// NewSoftwareManagementSelfCommand returns a cobra command for `self` subcommands
+func NewSoftwareManagementSelfCommand(cmdCli cli.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "self",
+		Short:  "self software management plugin",
+		Hidden: true,
+	}
+	cmd.AddCommand(
+		NewPrepareCommand(cmdCli),
+		NewInstallCommand(cmdCli),
+		NewRemoveCommand(cmdCli),
+		NewUpdateListCommand(cmdCli),
+		NewListCommand(cmdCli),
+		NewFinalizeCommand(cmdCli),
+		NewCheckCommand(cmdCli),
+	)
+	return cmd
+}

--- a/cli/self/finalize.go
+++ b/cli/self/finalize.go
@@ -1,0 +1,25 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+func NewFinalizeCommand(ctx cli.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "finalize",
+		Short: "Finalize container install/remove operation",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+			return nil
+		},
+	}
+	viper.SetDefault("container.pruneImages", false)
+	return cmd
+}

--- a/cli/self/install.go
+++ b/cli/self/install.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+type InstallCommand struct {
+	*cobra.Command
+
+	CommandContext cli.Cli
+	ModuleVersion  string
+	File           string
+}
+
+// installCmd represents the install command
+func NewInstallCommand(ctx cli.Cli) *cobra.Command {
+	command := &InstallCommand{
+		CommandContext: ctx,
+	}
+	cmd := &cobra.Command{
+		Use:   "install <MODULE_NAME>",
+		Short: "No-op command. self updates are handled by a dedicated workflow",
+		Args:  cobra.ExactArgs(1),
+		RunE:  command.RunE,
+	}
+
+	cmd.Flags().StringVar(&command.ModuleVersion, "module-version", "", "Software version to install")
+	cmd.Flags().StringVar(&command.File, "file", "", "File")
+	viper.SetDefault("container.alwaysPull", false)
+	command.Command = cmd
+	return cmd
+}
+
+func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
+	// don't do anything, just return without an error
+	return nil
+}

--- a/cli/self/list.go
+++ b/cli/self/list.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+	"github.com/thin-edge/tedge-container-plugin/pkg/container"
+)
+
+func newNotSupportedErr(err error) error {
+	return cli.ExitCodeError{
+		Code: 2,
+		Err:  err,
+	}
+}
+
+// listCmd represents the list command
+func NewListCommand(cliContext cli.Cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List containers",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+			ctx := context.Background()
+			containerCli, err := container.NewContainerClient()
+			if err != nil {
+				return newNotSupportedErr(err)
+			}
+
+			currentContainer, err := containerCli.Self(ctx)
+			if err != nil {
+				return newNotSupportedErr(err)
+			}
+
+			name := strings.TrimPrefix(currentContainer.Name, "/")
+			version := formatImageName(currentContainer.Config.Image)
+			_, wErr := fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", name, version)
+			return wErr
+		},
+	}
+}
+
+func formatImageName(v string) string {
+	if i := strings.LastIndex(v, "/"); i > -1 && i < len(v)-1 {
+		return v[i+1:]
+	}
+	return v
+}

--- a/cli/self/prepare.go
+++ b/cli/self/prepare.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+// prepareCmd represents the prepare command
+func NewPrepareCommand(ctx cli.Cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "prepare",
+		Short: "Prepare for install/removal",
+		Run: func(cmd *cobra.Command, args []string) {
+			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+		},
+	}
+}

--- a/cli/self/remove.go
+++ b/cli/self/remove.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+type RemoveCommand struct {
+	*cobra.Command
+
+	ModuleVersion string
+}
+
+// removeCmd represents the remove command
+func NewRemoveCommand(ctx cli.Cli) *cobra.Command {
+	command := &RemoveCommand{}
+	cmd := &cobra.Command{
+		Use:   "remove",
+		Short: "Not supported",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+			slog.Warn("Removing the main container is not supported")
+
+			return cli.ExitCodeError{
+				Err:  fmt.Errorf("not supported"),
+				Code: 2,
+			}
+		},
+	}
+	cmd.Flags().StringVar(&command.ModuleVersion, "module-version", "", "Software version to remove")
+	return cmd
+}

--- a/cli/self/updateList.go
+++ b/cli/self/updateList.go
@@ -1,0 +1,24 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package self
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+// updateListCmd represents the updateList command
+func NewUpdateListCommand(ctx cli.Cli) *cobra.Command {
+	return &cobra.Command{
+		Use:   "update-list",
+		Short: "Not implemented",
+		Run: func(cmd *cobra.Command, args []string) {
+			slog.Info("update-list is not supported")
+			os.Exit(1)
+		},
+	}
+}

--- a/cli/tools/cmd.go
+++ b/cli/tools/cmd.go
@@ -1,0 +1,19 @@
+package tools
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+)
+
+// NewToolsCommand returns a cobra command for `cli` subcommands
+func NewToolsCommand(cmdCli cli.Cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "tools",
+		Short:  "Container tools/utilities",
+		Hidden: true,
+	}
+	cmd.AddCommand(
+		NewContainerCloneCommand(cmdCli),
+	)
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thin-edge/tedge-container-plugin/cli/engine"
 	"github.com/thin-edge/tedge-container-plugin/cli/initcmd"
 	"github.com/thin-edge/tedge-container-plugin/cli/run"
+	"github.com/thin-edge/tedge-container-plugin/cli/tools"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
 )
 
@@ -88,6 +89,7 @@ func init() {
 		run.NewRunCommand(cliConfig),
 		engine.NewCliCommand(cliConfig),
 		initcmd.NewInitCommand(cliConfig),
+		tools.NewToolsCommand(cliConfig),
 	)
 
 	rootCmd.PersistentFlags().String("log-level", "info", "Log level")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,13 +49,17 @@ func Execute() {
 
 	err := rootCmd.Execute()
 	if err != nil {
-		switch err.(type) {
-		case cli.SilentError:
-			// Don't log error
+		exitCode := 1
+		switch vErr := err.(type) {
+		case cli.ExitCodeError:
+			exitCode = vErr.ExitCode()
+			if !vErr.Silent {
+				slog.Error("Command error", "err", err)
+			}
 		default:
 			slog.Error("Command error", "err", err)
 		}
-		os.Exit(1)
+		os.Exit(exitCode)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/thin-edge/tedge-container-plugin/cli/engine"
 	"github.com/thin-edge/tedge-container-plugin/cli/initcmd"
 	"github.com/thin-edge/tedge-container-plugin/cli/run"
+	"github.com/thin-edge/tedge-container-plugin/cli/self"
 	"github.com/thin-edge/tedge-container-plugin/cli/tools"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
 )
@@ -41,7 +42,7 @@ func Execute() {
 	args := os.Args
 	name := filepath.Base(args[0])
 	switch name {
-	case "container", "container-group":
+	case "container", "container-group", "self":
 		slog.Debug("Calling as a software management plugin.", "name", name, "args", args)
 		rootCmd.SetArgs(append([]string{name}, args[1:]...))
 	default:
@@ -89,6 +90,7 @@ func init() {
 		run.NewRunCommand(cliConfig),
 		engine.NewCliCommand(cliConfig),
 		initcmd.NewInitCommand(cliConfig),
+		self.NewSoftwareManagementSelfCommand(cliConfig),
 		tools.NewToolsCommand(cliConfig),
 	)
 

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ venv:
 
 # Build test images and test artifacts
 build-test:
+  docker buildx install
   docker build --load -t {{TEST_IMAGE}} -f ./test-images/{{TEST_IMAGE}}/Dockerfile .
   ./tests/data/apps/build.sh
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -22,7 +22,32 @@ import (
 
 var LinuxConfigFilePath = "/etc/tedge-container-plugin/config.toml"
 
-type SilentError error
+func NewExitCodeError(err error) *ExitCodeError {
+	return &ExitCodeError{
+		Code: 1,
+		Err:  err,
+	}
+}
+
+type ExitCodeError struct {
+	Err    error
+	Code   int
+	Silent bool
+}
+
+func (e ExitCodeError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return ""
+}
+
+func (e ExitCodeError) ExitCode() int {
+	if e.Code == 0 {
+		return 1
+	}
+	return e.Code
+}
 
 type Cli struct {
 	ConfigFile string

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -167,6 +167,10 @@ func (c *Cli) DeleteLegacyService() bool {
 	return viper.GetBool("delete_legacy")
 }
 
+func (c *Cli) ImageAlwaysPull() bool {
+	return viper.GetBool("container.alwaysPull")
+}
+
 func (c *Cli) GetMetricsInterval() time.Duration {
 	interval := viper.GetDuration("metrics.interval")
 	if interval < 60*time.Second {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -297,6 +297,46 @@ func (c *Cli) GetRegistryCredentials(url string) RepositoryAuth {
 	return creds
 }
 
+func (c *Cli) GetContainerRepositoryCredentialsFunc(imageRef string) func(ctx context.Context, attempt int) (string, error) {
+	return func(ctx context.Context, attempt int) (string, error) {
+		// Check credentials config
+		creds := c.GetRegistryCredentials(imageRef)
+
+		// Check credentials helper script
+		credentialsScript := "registry-credentials"
+		if utils.CommandExists(credentialsScript) {
+			scriptCtx, cancelScript := context.WithTimeout(ctx, 60*time.Second)
+			defer cancelScript()
+			scriptArgs := make([]string, 0)
+			scriptArgs = append(scriptArgs, "get", imageRef)
+			if attempt > 1 {
+				// signal to the credential helper that it should refresh the credentials
+				// in case it is cache them
+				scriptArgs = append(scriptArgs, "--refresh")
+			}
+			if customCreds, err := c.GetCredentialsFromScript(scriptCtx, credentialsScript, scriptArgs...); err != nil {
+				slog.Warn("Failed to get registry credentials.", "script", credentialsScript, "err", err)
+				return "", err
+			} else {
+				if customCreds.Username != "" && customCreds.Password != "" {
+					slog.Info("Using registry credentials returned by a helper.", "script", credentialsScript, "username", customCreds.Username)
+					creds.Username = customCreds.Username
+					creds.Password = customCreds.Password
+				}
+			}
+		}
+
+		if creds.IsSet() {
+			slog.Info("Pulling image from private registry.", "ref", imageRef, "username", creds.Username)
+			return container.GetRegistryAuth(creds.Username, creds.Password), nil
+		} else {
+			slog.Info("Pulling image.", "ref", imageRef)
+		}
+		// no explicit auth, but don't fail
+		return "", nil
+	}
+}
+
 func (c *Cli) GetCredentialsFromScript(ctx context.Context, script string, args ...string) (RepositoryAuth, error) {
 	cmd := exec.CommandContext(ctx, script, args...)
 	var outb, errb bytes.Buffer

--- a/pkg/container/auth.go
+++ b/pkg/container/auth.go
@@ -1,0 +1,21 @@
+package container
+
+import (
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/docker/docker/api/types/registry"
+)
+
+func GetRegistryAuth(username, password string) string {
+	authConfig := registry.AuthConfig{
+		Username: username,
+		Password: password,
+	}
+	encodedJSON, err := json.Marshal(authConfig)
+	if err != nil {
+		panic(err)
+	}
+	authStr := base64.URLEncoding.EncodeToString(encodedJSON)
+	return authStr
+}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1095,15 +1095,9 @@ func (c *ContainerClient) Fork(ctx context.Context, entrypoint []string, cmd []s
 	}
 
 	cloneOptions := CloneOptions{
-		// Entrypoint: append(strslice.StrSlice{}, entrypoint...),
-		// Cmd:        append(strslice.StrSlice{}, cmd...),
-		Image: currentContainer.Config.Image,
-	}
-	if len(entrypoint) > 0 {
-		cloneOptions.Entrypoint = append(strslice.StrSlice{}, entrypoint...)
-	}
-	if len(cmd) > 0 {
-		cloneOptions.Cmd = append(strslice.StrSlice{}, cmd...)
+		Entrypoint: append(strslice.StrSlice{}, entrypoint...),
+		Cmd:        append(strslice.StrSlice{}, cmd...),
+		Image:      currentContainer.Config.Image,
 	}
 	containerConfig := CloneContainerConfig(currentContainer.Config, cloneOptions)
 	labels := make(map[string]string)

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1079,12 +1079,17 @@ func (c *ContainerClient) CloneContainer(ctx context.Context, containerID string
 	return nil
 }
 
-func (c *ContainerClient) Fork(ctx context.Context, entrypoint []string, cmd []string) error {
+// Get the container id which is running the current process
+func (c *ContainerClient) Self(ctx context.Context) (types.ContainerJSON, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return err
+		return types.ContainerJSON{}, err
 	}
-	currentContainer, err := c.Client.ContainerInspect(ctx, hostname)
+	return c.Client.ContainerInspect(ctx, hostname)
+}
+
+func (c *ContainerClient) Fork(ctx context.Context, entrypoint []string, cmd []string) error {
+	currentContainer, err := c.Self(ctx)
 	if err != nil {
 		return fmt.Errorf("could not find current container. %s", err)
 	}

--- a/pkg/container/stdcopy.go
+++ b/pkg/container/stdcopy.go
@@ -1,0 +1,190 @@
+package container // import "github.com/docker/docker/pkg/stdcopy"
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// StdType is the type of standard stream
+// a writer can multiplex to.
+type StdType byte
+
+const (
+	// Stdin represents standard input stream type.
+	Stdin StdType = iota
+	// Stdout represents standard output stream type.
+	Stdout
+	// Stderr represents standard error steam type.
+	Stderr
+	// Systemerr represents errors originating from the system that make it
+	// into the multiplexed stream.
+	Systemerr
+
+	stdWriterPrefixLen = 8
+	stdWriterFdIndex   = 0
+	stdWriterSizeIndex = 4
+
+	startingBufLen = 32*1024 + stdWriterPrefixLen + 1
+)
+
+var bufPool = &sync.Pool{New: func() interface{} { return bytes.NewBuffer(nil) }}
+
+// stdWriter is wrapper of io.Writer with extra customized info.
+type stdWriter struct {
+	io.Writer
+	prefix byte
+}
+
+// Write sends the buffer to the underneath writer.
+// It inserts the prefix header before the buffer,
+// so stdcopy.StdCopy knows where to multiplex the output.
+// It makes stdWriter to implement io.Writer.
+func (w *stdWriter) Write(p []byte) (n int, err error) {
+	if w == nil || w.Writer == nil {
+		return 0, errors.New("Writer not instantiated")
+	}
+	if p == nil {
+		return 0, nil
+	}
+
+	header := [stdWriterPrefixLen]byte{stdWriterFdIndex: w.prefix}
+	binary.BigEndian.PutUint32(header[stdWriterSizeIndex:], uint32(len(p)))
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Write(header[:])
+	buf.Write(p)
+
+	n, err = w.Writer.Write(buf.Bytes())
+	n -= stdWriterPrefixLen
+	if n < 0 {
+		n = 0
+	}
+
+	buf.Reset()
+	bufPool.Put(buf)
+	return
+}
+
+// NewStdWriter instantiates a new Writer.
+// Everything written to it will be encapsulated using a custom format,
+// and written to the underlying `w` stream.
+// This allows multiple write streams (e.g. stdout and stderr) to be muxed into a single connection.
+// `t` indicates the id of the stream to encapsulate.
+// It can be stdcopy.Stdin, stdcopy.Stdout, stdcopy.Stderr.
+func NewStdWriter(w io.Writer, t StdType) io.Writer {
+	return &stdWriter{
+		Writer: w,
+		prefix: byte(t),
+	}
+}
+
+// StdCopy is a modified version of io.Copy.
+//
+// StdCopy will demultiplex `src`, assuming that it contains two streams,
+// previously multiplexed together using a StdWriter instance.
+// As it reads from `src`, StdCopy will write to `dstout` and `dsterr`.
+//
+// StdCopy will read until it hits EOF on `src`. It will then return a nil error.
+// In other words: if `err` is non nil, it indicates a real underlying error.
+//
+// `written` will hold the total number of bytes written to `dstout` and `dsterr`.
+func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error) {
+	var (
+		buf       = make([]byte, startingBufLen)
+		bufLen    = len(buf)
+		nr, nw    int
+		er, ew    error
+		out       io.Writer
+		frameSize int
+	)
+
+	for {
+		// Make sure we have at least a full header
+		for nr < stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		stream := StdType(buf[stdWriterFdIndex])
+		// Check the first byte to know where to write
+		switch stream {
+		case Stdin:
+			fallthrough
+		case Stdout:
+			// Write on stdout
+			out = dstout
+		case Stderr:
+			// Write on stderr
+			out = dsterr
+		case Systemerr:
+			// If we're on Systemerr, we won't write anywhere.
+			// NB: if this code changes later, make sure you don't try to write
+			// to outstream if Systemerr is the stream
+			out = nil
+		default:
+			return 0, fmt.Errorf("Unrecognized input header: %d", buf[stdWriterFdIndex])
+		}
+
+		// Retrieve the size of the frame
+		frameSize = int(binary.BigEndian.Uint32(buf[stdWriterSizeIndex : stdWriterSizeIndex+4]))
+
+		// Check if the buffer is big enough to read the frame.
+		// Extend it if necessary.
+		if frameSize+stdWriterPrefixLen > bufLen {
+			buf = append(buf, make([]byte, frameSize+stdWriterPrefixLen-bufLen+1)...)
+			bufLen = len(buf)
+		}
+
+		// While the amount of bytes read is less than the size of the frame + header, we keep reading
+		for nr < frameSize+stdWriterPrefixLen {
+			var nr2 int
+			nr2, er = src.Read(buf[nr:])
+			nr += nr2
+			if er == io.EOF {
+				if nr < frameSize+stdWriterPrefixLen {
+					return written, nil
+				}
+				break
+			}
+			if er != nil {
+				return 0, er
+			}
+		}
+
+		// we might have an error from the source mixed up in our multiplexed
+		// stream. if we do, return it.
+		if stream == Systemerr {
+			return written, fmt.Errorf("error from daemon in stream: %s", string(buf[stdWriterPrefixLen:frameSize+stdWriterPrefixLen]))
+		}
+
+		// Write the retrieved frame (without header)
+		nw, ew = out.Write(buf[stdWriterPrefixLen : frameSize+stdWriterPrefixLen])
+		if ew != nil {
+			return 0, ew
+		}
+
+		// If the frame has not been fully written: error
+		if nw != frameSize {
+			return 0, io.ErrShortWrite
+		}
+		written += int64(nw)
+
+		// Move the rest of the buffer to the beginning
+		copy(buf, buf[frameSize+stdWriterPrefixLen:])
+		// Move the index
+		nr -= frameSize + stdWriterPrefixLen
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -58,11 +58,12 @@ func RootDir(p string) string {
 	}
 }
 
-func Retry(maxAttempts int, wait time.Duration, action func(int) error) error {
+func Retry(maxAttempts int, wait time.Duration, action func(int) (any, error)) (any, error) {
 	var err error
+	var result any
 	attempt := 1
 	for {
-		err = action(attempt)
+		result, err = action(attempt)
 		if err == nil {
 			break
 		}
@@ -72,5 +73,5 @@ func Retry(maxAttempts int, wait time.Duration, action func(int) error) error {
 		}
 		time.Sleep(wait)
 	}
-	return err
+	return result, err
 }

--- a/tests/operations-clone.robot
+++ b/tests/operations-clone.robot
@@ -15,19 +15,19 @@ Check for Update
     DeviceLibrary.Execute Command    cmd=tedge-container engine docker container inspect app1 --format "{{.Id}}"
 
     # No update
-    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app1 --image httpd:2.4.61-alpine --check    exp_exit_code=2
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image httpd:2.4.61-alpine --check    exp_exit_code=2
 
     # Force update
-    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app1 --image httpd:2.4.61-alpine --check --force    exp_exit_code=0
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image httpd:2.4.61-alpine --check --force    exp_exit_code=0
 
     # Update is required as local image is not available
-    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app1 --image httpd:2.4.62-alpine --check    exp_exit_code=0
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image httpd:2.4.62-alpine --check    exp_exit_code=0
 
 Clone Existing Container
     Create Container    app2    httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app2 --format "{{.Id}}"
 
-    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app2 --force
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app2 --force
 
     ${next_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect app2 --format "{{.Id}}"
     Should Not Be Equal    ${next_container_id}    ${prev_container_id}
@@ -36,7 +36,7 @@ Clone Existing Container by Timeout Whilst Waiting For Exit
     Create Container    app3    httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app3 --format "{{.Id}}"
 
-    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app3 --force --wait-for-exit --stop-timeout 15s    exp_exit_code=!0
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app3 --force --wait-for-exit --stop-timeout 15s    exp_exit_code=!0
 
     ${next_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect app3 --format "{{.Id}}"
     Should Be Equal    ${next_container_id}    ${prev_container_id}
@@ -45,7 +45,7 @@ Clone Existing Container but Waiting For Exit
     Create Container    app4    httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app4 --format "{{.Id}}"
 
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine container-clone --container app4 --force --wait-for-exit --stop-timeout 60s 2>&1
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container tools container-clone --container app4 --force --wait-for-exit --stop-timeout 60s 2>&1
 
     Sleep    5s
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container stop app4

--- a/tests/operations-clone.robot
+++ b/tests/operations-clone.robot
@@ -1,0 +1,87 @@
+*** Settings ***
+Resource    ./resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
+Suite Setup    Suite Setup
+Test Teardown    Collect Logs
+
+Test Tags    docker    podman
+
+*** Test Cases ***
+
+Check for Update
+    Create Container    app1    httpd:2.4.61-alpine
+    DeviceLibrary.Execute Command    cmd=tedge-container engine docker container inspect app1 --format "{{.Id}}"
+
+    # No update
+    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app1 --image httpd:2.4.61-alpine --check    exp_exit_code=2
+
+    # Force update
+    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app1 --image httpd:2.4.61-alpine --check --force    exp_exit_code=0
+
+    # Update is required as local image is not available
+    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app1 --image httpd:2.4.62-alpine --check    exp_exit_code=0
+
+Clone Existing Container
+    Create Container    app2    httpd:2.4
+    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app2 --format "{{.Id}}"
+
+    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app2 --force
+
+    ${next_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect app2 --format "{{.Id}}"
+    Should Not Be Equal    ${next_container_id}    ${prev_container_id}
+
+Clone Existing Container by Timeout Whilst Waiting For Exit
+    Create Container    app3    httpd:2.4
+    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app3 --format "{{.Id}}"
+
+    DeviceLibrary.Execute Command    sudo tedge-container engine container-clone --container app3 --force --wait-for-exit --stop-timeout 15s    exp_exit_code=!0
+
+    ${next_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect app3 --format "{{.Id}}"
+    Should Be Equal    ${next_container_id}    ${prev_container_id}
+
+Clone Existing Container but Waiting For Exit
+    Create Container    app4    httpd:2.4
+    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app4 --format "{{.Id}}"
+
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine container-clone --container app4 --force --wait-for-exit --stop-timeout 60s 2>&1
+
+    Sleep    5s
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container stop app4
+
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Log    ${operation.to_json()["c8y_Command"]["result"]}
+
+    ${next_container_id}=    DeviceLibrary.Execute Command    cmd=tedge-container engine docker inspect app4 --format "{{.Id}}"
+    Should Not Be Equal    ${next_container_id}    ${prev_container_id}
+
+*** Keywords ***
+
+Suite Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
+
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir /data
+
+Create Container
+    [Arguments]    ${name}    ${image}
+    ${operation}=    Cumulocity.Install Software    {"name": "${name}", "version": "${image}", "softwareType": "container"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "${name}", "version": "${image}", "softwareType": "container"}
+
+Collect Logs
+    Collect Workflow Logs
+    Collect Systemd Logs
+
+Collect Systemd Logs
+    Execute Command    sudo journalctl -n 10000
+
+Collect Workflow Logs
+    Execute Command    cat /var/log/tedge/agent/*


### PR DESCRIPTION
Add `tools` subcommand to provide some core functionality when dealing with containers. This is only meant for internal use only, as the commands can change at any time!
* `clone-container` - clone an existing container and replace the image name