### PR TITLE
fix: launch s6-overlay service with sudo rights

### DIFF
--- a/packaging/services/s6-overlay/tedge-container-plugin/run
+++ b/packaging/services/s6-overlay/tedge-container-plugin/run
@@ -7,4 +7,10 @@ if [ "${SERVICE_TEDGE_CONTAINER_PLUGIN:-1}" -eq 0 ]; then
 fi
 
 exec 2>&1
-exec /usr/bin/tedge-container run --config /etc/tedge-container-plugin/config.toml
+
+SUDO=
+if command -V sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+fi
+
+exec $SUDO /usr/bin/tedge-container run --config /etc/tedge-container-plugin/config.toml


### PR DESCRIPTION
Fix a bug where the tedge-container-plugin s5-overlay service was not being launched with root access to the container engine socket resulting in permission denied errors for the monitoring functionality.