### PR TITLE
fix(s6-overlay): shutdown of service when run as root

### DIFF
--- a/packaging/services/s6-overlay/tedge-container-plugin/finish
+++ b/packaging/services/s6-overlay/tedge-container-plugin/finish
@@ -1,0 +1,7 @@
+#!/command/with-contenv sh
+PROC_PID=$(pgrep -f "/usr/bin/tedge-container run" ||:)
+if [ -n "$PROC_PID" ]; then
+    echo "sending SIGTERM to pid=$PROC_PID"
+    sudo kill -15 "$PROC_PID" || echo "Failed to stop tedge-container service"
+fi
+exit 0


### PR DESCRIPTION
Since the tedge-container service needs access to the container engine socket, it is launched with using sudo, however this means that the s6-overlay shutdown signals are ignored (as the shutdown signal is sent by a non-root user).

Instead, a manual s6-overlay "finish" script is used to kill the service using sudo.