### PR TITLE
feat: support private registries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,8 +10,6 @@ on:
   pull_request_target:
     branches: [ next ]
   merge_group:
-  push:
-    branches: [ feat-support-private-registries ]
 jobs:
   approve:
     name: Approve
@@ -41,8 +39,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { image: debian-systemd-docker-cli }
-          - { image: debian-systemd-podman-cli }
+          - { image: debian-systemd-docker-cli, test_options: "--include docker" }
+          - { image: debian-systemd-podman-cli, test_options: "--include podman" }
 
     steps:
       - name: Checkout
@@ -94,7 +92,7 @@ jobs:
           just build-test
 
       - name: Run tests
-        run: just test
+        run: just test ${{ matrix.job.test_options }}
 
       - name: Upload test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,8 @@ on:
   pull_request_target:
     branches: [ next ]
   merge_group:
+  push:
+    branches: [ feat-support-private-registries ]
 jobs:
   approve:
     name: Approve
@@ -54,6 +56,11 @@ jobs:
           echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
+          echo 'PRIVATE_IMAGE="${{ secrets.PRIVATE_IMAGE }}"' >> .env
+          echo 'PRIVATE_IMAGE_VERSION="${{ secrets.PRIVATE_IMAGE_VERSION }}"' >> .env
+          echo 'REGISTRY1_REPO="${{ secrets.REGISTRY1_REPO }}"' >> .env
+          echo 'REGISTRY1_USERNAME="${{ secrets.REGISTRY1_USERNAME }}"' >> .env
+          echo 'REGISTRY1_PASSWORD="${{ secrets.REGISTRY1_PASSWORD }}"' >> .env
 
       - uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ interactive_console_output.xml
 tests/data/apps/app1.tar.gz
 tests/data/apps/app2.zip
 tests/data/apps/app3.tar
+tests/data/apps/app4.tar.gz
 
 # MacOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The software package properties are also describe below:
 |`softwareType`|`container`. This indicates that the package should be managed by the `container` software management plugin|
 |`url`|Optional url pointing to the container image in a tarball format. The file is downloaded and loaded into the container engine, prior to starting the container. The image inside the gzip **MUST** match the one given by the `version` property!|
 
+#### Private container registries
+
+Pulling image from private container registries is supported. Check out the [container registries](./docs/CONTAINER_REGISTRIES.md) documentation for the available options.
+
 ### Install/remove a `container-group`
 
 A `container-group` is the name given to deploy a `docker-compose.yaml` file or an archive (zip or gzip file) with the `docker-compose.yaml` file at the root level of the archive. A docker compose file allows use to deploy multiple containers/networks/volumes and allows you maximum control over how the container is started. This means you can create a complex setup of persisted volumes, isolated networks, and also facilitate communication between containers. Check out the [docker compose documentation](https://docs.docker.com/compose/compose-file/) for more details on how to write your own service definition.

--- a/cli/container/install.go
+++ b/cli/container/install.go
@@ -169,7 +169,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 				slog.Info("Executing registry credentials script.", "script", credentialsScript)
 				scriptCtx, cancelScript := context.WithTimeout(ctx, 60*time.Second)
 				defer cancelScript()
-				if customCreds, err := c.CommandContext.GetCredentialsFromScript(scriptCtx, credentialsScript, imageRef); err != nil {
+				if customCreds, err := c.CommandContext.GetCredentialsFromScript(scriptCtx, credentialsScript, "get", imageRef); err != nil {
 					slog.Warn("Failed to get registry credentials.", "script", credentialsScript, "err", err)
 				} else {
 					if customCreds.Username != "" && customCreds.Password != "" {

--- a/docs/CONTAINER_REGISTRIES.md
+++ b/docs/CONTAINER_REGISTRIES.md
@@ -9,10 +9,10 @@ Container images can be pulled from private repositories, however you must provi
 Container registry credentials can be provided dynamically to plugin by creating an executable file called `registry-credentials` which then returns the credentials to use for the api call.
 
 
-The `registry-credentials` is executed by tedge-container-plugin when it attempts to pull an image, and the image/tag is passed as the first argument to the executable.
+The `registry-credentials` is executed by tedge-container-plugin when it attempts to pull an image, and the image/tag is passed as an argument to the executable.
 
 ```sh
-registry-credentials IMAGE_TAG
+registry-credentials get IMAGE_TAG
 ```
 
 The script should return with an exit-code 0 and the credentials
@@ -28,20 +28,37 @@ The script should return with an exit-code 0 and the credentials
 
 ```sh
 #!/bin/sh
-IMAGE="$1"
+set -e
+ACTION="$1"
+shift
 
-# Write log messages to stderr
-echo "Retrieving private repository credentials for $IMAGE" >&2
+get_credentials() {
+    IMAGE="$1"
+    # Write log messages to stderr
+    echo "Retrieving private repository credentials for $IMAGE" >&2
 
-# Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
+    # Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
 
-# Then return credentials
-cat <<EOT
+    # Then return credentials
+    cat <<EOT
 {
     "username": "myuser",
     "password": "..."
 }
 EOT
+}
+
+case "$ACTION" in
+    get)
+        get_credentials "$@"
+        ;;
+    *)
+        echo "Unknown command" >&2
+        exit 1
+        ;;
+esac
+
+exit 0
 ```
 
 ### Using static settings

--- a/docs/CONTAINER_REGISTRIES.md
+++ b/docs/CONTAINER_REGISTRIES.md
@@ -1,0 +1,81 @@
+# Container registries
+
+## Private container registries
+
+Container images can be pulled from private repositories, however you must provide credentials by either adding credentials to a file or environment variables.
+
+### Set credentials dynamically
+
+Container registry credentials can be provided dynamically to plugin by creating an executable file called `registry-credentials` which then returns the credentials to use for the api call.
+
+
+The `registry-credentials` is executed by tedge-container-plugin when it attempts to pull an image, and the image/tag is passed as the first argument to the executable.
+
+```sh
+registry-credentials IMAGE_TAG
+```
+
+The script should return with an exit-code 0 and the credentials
+
+```json
+{
+   "username": "myuser",
+   "password": "..."
+}
+```
+
+**file: /usr/bin/registry-credentials**
+
+```sh
+#!/bin/sh
+IMAGE="$1"
+
+# Write log messages to stderr
+echo "Retrieving private repository credentials for $IMAGE" >&2
+
+# Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
+
+# Then return credentials
+cat <<EOT
+{
+    "username": "myuser",
+    "password": "..."
+}
+EOT
+```
+
+### Using static settings
+
+Static credentials for different repositories can be provided in the following file.
+
+**file: /data/tedge-container-plugin/credentials.toml**
+
+```toml
+[registry1]
+repo = "docker.io"
+username = "example"
+password = ""
+
+[registry2]
+repo = "quay.io"
+username = "otherUser"
+password = ""
+```
+
+The file location of the `credentials.toml` file location can be changed by setting the following value in the `tedge-container-plugin.toml`:
+
+```toml
+registry.credentials_path = "/data/tedge-container-plugin/credentials.toml"
+```
+
+You can also control the same registry settings using environment variables:
+
+```sh
+CONTAINER_REGISTRY1_REPO=docker.io
+CONTAINER_REGISTRY1_USERNAME=example
+CONTAINER_REGISTRY1_PASSWORD=
+
+CONTAINER_REGISTRY2_REPO=quay.io
+CONTAINER_REGISTRY2_USERNAME=otherUser
+CONTAINER_REGISTRY2_PASSWORD=
+```

--- a/justfile
+++ b/justfile
@@ -15,6 +15,11 @@ init-dotenv:
   @echo "C8Y_BASEURL=$C8Y_BASEURL" >> .env
   @echo "C8Y_USER=$C8Y_USER" >> .env
   @echo "C8Y_PASSWORD=$C8Y_PASSWORD" >> .env
+  @echo "PRIVATE_IMAGE=docker.io/example/app" >> .env
+  @echo "PRIVATE_IMAGE_VERSION=app:latest" >> .env
+  @echo "REGISTRY1_REPO=docker.io" >> .env
+  @echo "REGISTRY1_USERNAME=" >> .env
+  @echo "REGISTRY1_PASSWORD=" >> .env
 
 # Run linting
 lint:
@@ -41,7 +46,7 @@ venv:
 
 # Build test images and test artifacts
 build-test:
-  docker build -t {{IMAGE}} -f ./test-images/{{IMAGE_SRC}}/Dockerfile .
+  docker build --load -t {{IMAGE}} -f ./test-images/{{IMAGE_SRC}}/Dockerfile .
   ./tests/data/apps/build.sh
 
 # Run tests

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -67,3 +67,7 @@ enabled = true
 [delete_from_cloud]
 # Enable/Disable the deletion of services from the cloud (using REST API) when a container is removed
 enabled = true
+
+[registry]
+# Path to the file containing container registry credentials
+credentials_path = "/data/tedge-container-plugin/credentials.toml"

--- a/tests/data/apps/app4/Dockerfile
+++ b/tests/data/apps/app4/Dockerfile
@@ -1,0 +1,12 @@
+FROM ghcr.io/thin-edge/tedge-container-bundle:20241123.1853
+
+USER root
+RUN apk del \
+        docker-cli \
+        docker-cli-compose \
+    && apk add --no-cache \
+        podman-remote
+
+ENV REGISTRY_AUTH_FILE=/run/containers/0/auth.json
+USER tedge
+CMD [ "sleep", "infinity" ]

--- a/tests/data/apps/app4/docker-compose.yaml
+++ b/tests/data/apps/app4/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  main:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - /run/podman/podman.sock:/run/podman/podman.sock
+      # Allow calling "podman-remote login" from inside the container and persist credentials on the host
+      - /run/containers/0:/run/containers/0
+    command:
+      - sleep
+      - infinity

--- a/tests/data/apps/build.sh
+++ b/tests/data/apps/build.sh
@@ -11,7 +11,9 @@ pushd "$SCRIPT_DIR" >/dev/null ||:
 (cd app2 && zip ../app2.zip docker-compose.yaml Dockerfile static/*)
 
 if command -V docker >/dev/null 2>&1; then
-    (cd app3 && docker build -t app3 . && docker save app3 > ../app3.tar)
+    (cd app3 && docker build --load -t app3 . && docker save app3 > ../app3.tar)
 fi
+
+(cd app4 && tar czvf ../app4.tar.gz docker-compose.yaml Dockerfile)
 
 popd ||:

--- a/tests/data/registry-credentials
+++ b/tests/data/registry-credentials
@@ -1,0 +1,9 @@
+#!/bin/sh
+IMAGE="$1"
+echo "Retrieving private repository credentials for $IMAGE" >&2
+cat <<EOT
+{
+    "username": "@@USERNAME@@",
+    "password": "@@PASSWORD@@"
+}
+EOT

--- a/tests/data/registry-credentials
+++ b/tests/data/registry-credentials
@@ -1,9 +1,33 @@
 #!/bin/sh
-IMAGE="$1"
-echo "Retrieving private repository credentials for $IMAGE" >&2
-cat <<EOT
+set -e
+
+ACTION="$1"
+shift
+
+get_credentials() {
+    IMAGE="$1"
+    # Write log messages to stderr
+    echo "Retrieving private repository credentials for $IMAGE" >&2
+
+    # Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
+
+    # Then return credentials
+    cat <<EOT
 {
     "username": "@@USERNAME@@",
     "password": "@@PASSWORD@@"
 }
 EOT
+}
+
+case "$ACTION" in
+    get)
+        get_credentials "$@"
+        ;;
+    *)
+        echo "Unknown command" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/tests/installation.robot
+++ b/tests/installation.robot
@@ -5,6 +5,7 @@ Library    DeviceLibrary    bootstrap_script=bootstrap.sh
 
 Test Setup    Test Setup
 Test Teardown    Collect Logs
+Test Tags    podman    docker
 
 *** Test Cases ***
 

--- a/tests/operations-private-registries.robot
+++ b/tests/operations-private-registries.robot
@@ -37,7 +37,7 @@ Install/uninstall container package from private repository - credentials script
 
 Install/uninstall container package from private repository - engine credentials
     [Documentation]    login to registry from host
-    [Tags]    docker    podman
+    [Tags]    podman
     DeviceLibrary.Execute Command    tedge-container engine docker login docker.io -u '${REGISTRY1_USERNAME}' --password '${REGISTRY1_PASSWORD}'
     ${operation}=    Cumulocity.Install Software    {"name": "testapp3", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60

--- a/tests/operations-private-registries.robot
+++ b/tests/operations-private-registries.robot
@@ -1,0 +1,90 @@
+*** Settings ***
+Resource    ./resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
+Test Setup    Test Setup
+Test Teardown    Collect Logs
+
+*** Variables ***
+
+${PRIVATE_IMAGE}            %{PRIVATE_IMAGE=}
+${PRIVATE_IMAGE_VERSION}    %{PRIVATE_IMAGE_VERSION=}
+${REGISTRY1_REPO}           %{REGISTRY1_REPO=docker.io}
+${REGISTRY1_USERNAME}       %{REGISTRY1_USERNAME=}
+${REGISTRY1_PASSWORD}       %{REGISTRY1_PASSWORD=}
+
+*** Test Cases ***
+
+Install/uninstall container package from private repository - credentials file
+    [Tags]    docker    podman
+    DeviceLibrary.Execute Command    
+    ...    cmd=printf -- '[registry1]\nrepo = "${REGISTRY1_REPO}"\nusername = "${REGISTRY1_USERNAME}"\npassword = "${REGISTRY1_PASSWORD}"\n' > /data/tedge-container-plugin/credentials.toml
+
+    ${operation}=    Cumulocity.Install Software    {"name": "testapp1", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "testapp1", "version": "${PRIVATE_IMAGE_VERSION}", "softwareType": "container"}
+
+Install/uninstall container package from private repository - credentials script
+    [Tags]    docker    podman
+    Transfer To Device    ${CURDIR}/data/registry-credentials    /usr/bin/
+    DeviceLibrary.Execute Command    cmd=sed -i 's|@@USERNAME@@|${REGISTRY1_USERNAME}|g' /usr/bin/registry-credentials
+    DeviceLibrary.Execute Command    cmd=sed -i 's|@@PASSWORD@@|${REGISTRY1_PASSWORD}|g' /usr/bin/registry-credentials
+
+    ${operation}=    Cumulocity.Install Software    {"name": "testapp2", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "testapp2", "version": "${PRIVATE_IMAGE_VERSION}", "softwareType": "container"}
+
+Install/uninstall container package from private repository - engine credentials
+    [Documentation]    login to registry from host
+    [Tags]    docker    podman
+    DeviceLibrary.Execute Command    tedge-container engine docker login docker.io -u '${REGISTRY1_USERNAME}' --password '${REGISTRY1_PASSWORD}'
+    ${operation}=    Cumulocity.Install Software    {"name": "testapp3", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "testapp3", "version": "${PRIVATE_IMAGE_VERSION}", "softwareType": "container"}
+
+Install/uninstall container package from private repository - docker from docker
+    [Documentation]    login inside a container with the auth file mounted from the host
+    [Tags]    podman
+
+    # Start a container
+    DeviceLibrary.Execute Command    mkdir -p /run/containers/0/
+    Install container-group file    app4    2.0.0    app4    ${CURDIR}/data/apps/app4.tar.gz
+    Device Should Have Installed Software    {"name": "app4", "version": "2.0.0", "softwareType": "container-group"}
+    Cumulocity.Should Have Services    name=app4@main    service_type=container-group    status=up
+
+    # Deploy a new container from inside the container
+    DeviceLibrary.Execute Command    tedge-container engine docker exec app4_main_1 sudo tedge-container engine docker login docker.io -u '${REGISTRY1_USERNAME}' --password '${REGISTRY1_PASSWORD}' --authfile /run/containers/0/auth.json
+    DeviceLibrary.Execute Command    tedge-container engine docker exec app4_main_1 sudo tedge-container container install app5 --module-version ${PRIVATE_IMAGE}
+
+*** Keywords ***
+
+Test Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
+
+    # Create common network for all containers
+    ${operation}=    Cumulocity.Execute Shell Command    set -a; . /etc/tedge-container-plugin/env; docker network create tedge ||:
+
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir -p /data/tedge-container-plugin/
+
+
+Install container-group file
+    [Arguments]    ${package_name}    ${package_version}    ${service_name}    ${file}
+    ${binary_url}=    Cumulocity.Create Inventory Binary    ${package_name}    container-group    file=${file}
+    ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=300
+
+
+Collect Logs
+    Collect Workflow Logs
+    Collect Systemd Logs
+
+Collect Systemd Logs
+    Execute Command    sudo journalctl -n 10000
+
+Collect Workflow Logs
+    Execute Command    cat /var/log/tedge/agent/*

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -5,6 +5,7 @@ Library    DeviceLibrary    bootstrap_script=bootstrap.sh
 
 Suite Setup    Suite Setup
 Test Teardown    Collect Logs
+Test Tags    podman    docker
 
 *** Test Cases ***
 

--- a/tests/telemetry-main.robot
+++ b/tests/telemetry-main.robot
@@ -4,6 +4,7 @@ Library    Cumulocity
 Library    DeviceLibrary    bootstrap_script=bootstrap.sh
 
 Test Setup    Test Setup
+Test Tags    podman    docker
 
 *** Test Cases ***
 


### PR DESCRIPTION
In addition to the standard way of support private repository credentials using the standard `docker login` or `podman/podman-remote login`, tedge-container-plugin supports setting the container repository credentials which are used by the `container` sm-plugin when pulling in new images.

See the [docs](https://github.com/thin-edge/tedge-container-plugin/blob/7649e6873e7302a48de214cf3f0c082a3489fc13/docs/CONTAINER_REGISTRIES.md) for details.

Though currently pulling from private repositories is not supported when using `container-group` as currently the image pull is performed by `docker compose` (or `podman-compose`), and not the tedge-container-plugin.