### PR TITLE
feat: improve image pull and private repo handling

### DIFF
--- a/docs/CONTAINER_REGISTRIES.md
+++ b/docs/CONTAINER_REGISTRIES.md
@@ -12,10 +12,21 @@ Container registry credentials can be provided dynamically to plugin by creating
 The `registry-credentials` is executed by tedge-container-plugin when it attempts to pull an image, and the image/tag is passed as an argument to the executable.
 
 ```sh
-registry-credentials get IMAGE_TAG
+registry-credentials get IMAGE_TAG [--refresh]
 ```
 
-The script should return with an exit-code 0 and the credentials
+For example:
+
+```sh
+# Get credentials for the registry related to an image
+registry-credentials get ghcr.io/thin-edge/tedge:1.3.1
+
+# Get credentials but the tedge-container-plugin has indicated that a new token
+# should be issued as the last token failed
+registry-credentials get ghcr.io/thin-edge/tedge:1.3.1 --refresh
+```
+
+The script should return with an exit-code 0 and the credentials in the following json format:
 
 ```json
 {
@@ -34,11 +45,16 @@ shift
 
 get_credentials() {
     IMAGE="$1"
+
     # Write log messages to stderr
-    echo "Retrieving private repository credentials for $IMAGE" >&2
 
-    # Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
-
+    if [ "$2" = "--refresh" ]; then
+        # Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
+        echo "Retrieving private repository credentials for $IMAGE" >&2
+    else
+        echo "Using credentials from cache (assuming they have already been cached)" >&2
+    fi
+    
     # Then return credentials
     cat <<EOT
 {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/codeclysm/extract/v4 v4.0.0
+	github.com/distribution/reference v0.6.0
 	github.com/docker/docker v27.3.1+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/eclipse/paho.mqtt.golang v1.5.0
@@ -19,7 +20,6 @@ require (
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -247,7 +247,9 @@ func (c *Cli) GetRegistryCredentials(url string) RepositoryAuth {
 	if err := config.ReadInConfig(); err == nil {
 		slog.Info("Using config file", "path", viper.ConfigFileUsed())
 	} else {
-		slog.Warn("Could not read credentials files. Continuing anyway.", "path", credentialsFile, "err", err)
+		if config.ConfigFileUsed() != "" {
+			slog.Warn("Could not read credentials files. Continuing anyway.", "path", credentialsFile, "err", err)
+		}
 	}
 
 	urlFromImage := GetImageSource(url)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -279,6 +279,7 @@ func (c *Cli) GetCredentialsFromScript(ctx context.Context, script string, args 
 	cmd.Stderr = &errb
 
 	creds := RepositoryAuth{}
+	slog.Info("Executing credentials plugin.", "cmd", script, "args", args)
 
 	if err := cmd.Run(); err != nil {
 		return creds, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 )
 
 func PathExists(p string) bool {
@@ -55,4 +56,21 @@ func RootDir(p string) string {
 		}
 		p = v1
 	}
+}
+
+func Retry(maxAttempts int, wait time.Duration, action func(int) error) error {
+	var err error
+	attempt := 1
+	for {
+		err = action(attempt)
+		if err == nil {
+			break
+		}
+		attempt += 1
+		if attempt > maxAttempts {
+			break
+		}
+		time.Sleep(wait)
+	}
+	return err
 }

--- a/tests/data/registry-credentials-with-cache
+++ b/tests/data/registry-credentials-with-cache
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+
+ACTION="$1"
+shift
+
+get_credentials() {
+    IMAGE="$1"
+    USE_CACHE=1
+    if [ "$2" = "--refresh" ]; then
+        USE_CACHE=0
+        echo "Refreshing credentials by deleting any stored cache" >&2
+    fi
+
+    if [ "$USE_CACHE" = 1 ]; then
+        echo "Using cached private repository credentials for $IMAGE" >&2
+        cat <<EOT
+{
+    "username": "invalid",
+    "password": "invalid"
+}
+EOT
+    else
+        # Fetch some credentials from anywhere, e.g. api, local file storage, keychain etc.
+        echo "Retrieving private repository credentials for $IMAGE" >&2
+        cat <<EOT
+{
+    "username": "@@USERNAME@@",
+    "password": "@@PASSWORD@@"
+}
+EOT
+    fi
+}
+
+case "$ACTION" in
+    get)
+        get_credentials "$@"
+        ;;
+    *)
+        echo "Unknown command" >&2
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/tests/operations-private-registries.robot
+++ b/tests/operations-private-registries.robot
@@ -35,6 +35,16 @@ Install/uninstall container package from private repository - credentials script
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Device Should Have Installed Software    {"name": "testapp2", "version": "${PRIVATE_IMAGE_VERSION}", "softwareType": "container"}
 
+Install/uninstall container package from private repository - credentials script with cache
+    [Tags]    docker    podman
+    Transfer To Device    ${CURDIR}/data/registry-credentials-with-cache    /usr/bin/registry-credentials
+    DeviceLibrary.Execute Command    cmd=sed -i 's|@@USERNAME@@|${REGISTRY1_USERNAME}|g' /usr/bin/registry-credentials
+    DeviceLibrary.Execute Command    cmd=sed -i 's|@@PASSWORD@@|${REGISTRY1_PASSWORD}|g' /usr/bin/registry-credentials
+
+    ${operation}=    Cumulocity.Install Software    {"name": "testapp2", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "testapp2", "version": "${PRIVATE_IMAGE_VERSION}", "softwareType": "container"}
+
 Install/uninstall container package from private repository - engine credentials
     [Documentation]    login to registry from host
     [Tags]    docker    podman


### PR DESCRIPTION
Improve pulling images from public and private repositories by:

* Support calling the registry-credentials script again if the first image pull attempt fails (with an additional flag `--refresh`) to indicate that the previously provided value may not be valid any more.
* Fix container image reference parsing to check the domain name.