### PR TITLE
fix: container clone compatibility with podman v4

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1214,6 +1214,7 @@ func CloneHostConfig(ref *container.HostConfig, opts CloneOptions) *container.Ho
 		SecurityOpt:     ref.SecurityOpt,
 		GroupAdd:        ref.GroupAdd,
 		Runtime:         ref.Runtime,
+		ContainerIDFile: ref.ContainerIDFile,
 	}
 
 	if opts.IgnorePorts {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1129,7 +1129,7 @@ func (c *ContainerClient) Fork(ctx context.Context, entrypoint []string, cmd []s
 
 	startErr := c.Client.ContainerStart(ctx, resp.ID, container.StartOptions{})
 	if startErr != nil {
-		slog.Error("Failed to start container.", "id", resp.ID, "err", err)
+		slog.Error("Failed to start container.", "id", resp.ID, "err", startErr)
 		return startErr
 	}
 	slog.Info("Successfully created forked container.", "id", resp.ID)

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1201,7 +1201,6 @@ func CloneHostConfig(ref *container.HostConfig, opts CloneOptions) *container.Ho
 		Tmpfs:           ref.Tmpfs,
 		PortBindings:    ref.PortBindings,
 		PublishAllPorts: ref.PublishAllPorts,
-		ShmSize:         ref.ShmSize,
 		ExtraHosts:      append(ref.ExtraHosts, opts.ExtraHosts...),
 		OomScoreAdj:     ref.OomScoreAdj,
 		ReadonlyRootfs:  ref.ReadonlyRootfs,


### PR DESCRIPTION
Compatibility improvements to support cloning containers (used in self-updates) for podman v4.x