### PR TITLE
feat(internal): add stop-after to container-clone

### DIFF
--- a/cli/tools/container_clone.go
+++ b/cli/tools/container_clone.go
@@ -169,7 +169,7 @@ func (c *ContainerCloneCommand) RunE(cmd *cobra.Command, args []string) error {
 			// of a container after creation
 			// "--wait-for-exit",
 			forkCmd = append(forkCmd, "--wait-for-exit")
-			forkCmd = append(forkCmd, "stop-timeout", c.StopTimeout.String())
+			forkCmd = append(forkCmd, "--stop-timeout", c.StopTimeout.String())
 		}
 
 		if c.StopAfter > 0 {

--- a/cli/tools/container_clone.go
+++ b/cli/tools/container_clone.go
@@ -30,6 +30,7 @@ type ContainerCloneCommand struct {
 	Image          string
 	Duration       time.Duration
 	StopTimeout    time.Duration
+	StopAfter      time.Duration
 	AutoRemove     bool
 	AddHost        []string
 	Env            []string
@@ -52,6 +53,7 @@ func NewContainerCloneCommand(ctx cli.Cli) *cobra.Command {
 	cmd.Flags().StringVar(&command.Image, "image", "", "Container image")
 	cmd.Flags().DurationVar(&command.Duration, "duration", 15*time.Second, "How long to wait for the clone container to be healthy")
 	cmd.Flags().DurationVar(&command.StopTimeout, "stop-timeout", 60*time.Second, "Timeout used whilst waiting for container to stop. Only used with --wait-for-exit")
+	cmd.Flags().DurationVar(&command.StopAfter, "stop-after", 10*time.Second, "Timeout container after a delay. Incompatible with --wait-for-exit")
 	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the closed container on exit")
 	cmd.Flags().StringSliceVar(&command.AddHost, "add-host", []string{}, "Add extra hosts to the container")
 	cmd.Flags().StringSliceVarP(&command.Env, "env", "e", []string{}, "Environment variables to add to the container")
@@ -170,6 +172,10 @@ func (c *ContainerCloneCommand) RunE(cmd *cobra.Command, args []string) error {
 			forkCmd = append(forkCmd, "stop-timeout", c.StopTimeout.String())
 		}
 
+		if c.StopAfter > 0 {
+			forkCmd = append(forkCmd, "--stop-after", c.StopAfter.String())
+		}
+
 		if c.AutoRemove {
 			forkCmd = append(forkCmd, "--rm")
 		}
@@ -219,6 +225,7 @@ func (c *ContainerCloneCommand) RunE(cmd *cobra.Command, args []string) error {
 		HealthyAfter: c.Duration,
 		WaitForExit:  c.WaitForExit,
 		StopTimeout:  c.StopTimeout,
+		StopAfter:    c.StopAfter,
 		AutoRemove:   c.AutoRemove,
 		Env:          c.Env,
 		ExtraHosts:   c.AddHost,

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -943,6 +943,7 @@ func (c *ContainerClient) ContainerLogs(ctx context.Context, w io.Writer, contai
 type CloneOptions struct {
 	Image        string
 	HealthyAfter time.Duration
+	StopAfter    time.Duration
 	StopTimeout  time.Duration
 	WaitForExit  bool
 	AutoRemove   bool
@@ -1001,6 +1002,12 @@ func (c *ContainerClient) CloneContainer(ctx context.Context, containerID string
 		}
 		slog.Info("Container stopped.", "id", prevContainer.ID)
 	} else {
+		// Pause before stopping the container
+		if opts.StopAfter > 0 {
+			slog.Info("Waiting before stopping container.", "id", prevContainer.ID, "duration", opts.StopAfter)
+			time.Sleep(opts.StopAfter)
+		}
+
 		slog.Info("Stopping previous container.", "id", prevContainer.ID, "name", prevContainer.Name)
 		stopErr := c.Client.ContainerStop(ctx, prevContainer.ID, container.StopOptions{})
 		if stopErr != nil {


### PR DESCRIPTION
Allow the user to control when the container is stopped