### PR TITLE
fix: install configuration file under tedge plugins folder

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,8 +114,8 @@ nfpms:
         packager: apk
 
       # Config
-      - src: ./packaging/config.*
-        dst: /etc/tedge-container-plugin/
+      - src: ./packaging/config.toml
+        dst: /etc/tedge/plugins/tedge-container-plugin.toml
         file_info:
           mode: 0644
           owner: tedge


### PR DESCRIPTION
Install the `tedge-container-plugin.toml` configuration file under the `/etc/tedge/plugins` folder so it can be easily accessed and backed up with other tedge config.