### PR TITLE
fix: only use self sm-plugin for legacy updates

### DIFF
--- a/cli/self/cmd.go
+++ b/cli/self/cmd.go
@@ -1,9 +1,18 @@
 package self
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
 )
+
+func CalledAsSMPlugin() bool {
+	args := os.Args
+	name := filepath.Base(args[0])
+	return name == "self"
+}
 
 // NewSoftwareManagementSelfCommand returns a cobra command for `self` subcommands
 func NewSoftwareManagementSelfCommand(cmdCli cli.Cli) *cobra.Command {

--- a/cli/self/list.go
+++ b/cli/self/list.go
@@ -29,6 +29,12 @@ func NewListCommand(cliContext cli.Cli) *cobra.Command {
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+
+			if CalledAsSMPlugin() {
+				slog.Info("Called as sm-plugin, ignoring legacy plugin. 'container' is used for updates")
+				return nil
+			}
+
 			ctx := context.Background()
 			containerCli, err := container.NewContainerClient()
 			if err != nil {


### PR DESCRIPTION
Provide the `self` sm-plugin to enable updating from legacy versions but don't print out the list of software items (to avoid duplciate entries as the `container` type.