### PR TITLE
feat(internal): allow users to add labels when cloning container or running in context

### DIFF
--- a/cli/tools/run_context.go
+++ b/cli/tools/run_context.go
@@ -28,6 +28,7 @@ type ContainerRunInContextCommand struct {
 	Env         []string
 	AutoRemove  bool
 	Entrypoint  string
+	Labels      []string
 }
 
 // NewRunRemoteAccessCommand creates a new c8y remote access command
@@ -47,6 +48,7 @@ func NewContainerRunInContextCommand(ctx cli.Cli) *cobra.Command {
 	cmd.Flags().StringVar(&command.Entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	cmd.Flags().StringSliceVarP(&command.Env, "env", "e", []string{}, "Set environment variables")
 	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the closed container on exit")
+	cmd.Flags().StringSliceVarP(&command.Labels, "label", "l", []string{}, "Set meta data on a container")
 
 	command.Command = cmd
 	return cmd
@@ -140,6 +142,7 @@ func (c *ContainerRunInContextCommand) RunE(cmd *cobra.Command, args []string) e
 		Entrypoint:  entrypoint,
 		Cmd:         containerCmd,
 		IgnorePorts: true,
+		Labels:      container.FormatLabels(c.Labels),
 	}
 
 	// Container config

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -971,6 +971,7 @@ type CloneOptions struct {
 	Cmd          strslice.StrSlice
 	Entrypoint   strslice.StrSlice
 	IgnorePorts  bool
+	Labels       map[string]string
 }
 
 func FormatContainerName(v string) string {
@@ -1268,6 +1269,11 @@ func CloneContainerConfig(ref *container.Config, opts CloneOptions) *container.C
 	if opts.Image != "" {
 		clonedConfig.Image = opts.Image
 	}
+
+	for label, value := range opts.Labels {
+		clonedConfig.Labels[label] = value
+	}
+
 	clonedConfig.Env = append(clonedConfig.Env, opts.Env...)
 	return clonedConfig
 }
@@ -1329,4 +1335,14 @@ func CloneNetworkConfig(ref *types.NetworkSettings) *network.NetworkingConfig {
 		}
 	}
 	return networkConfig
+}
+
+func FormatLabels(labels []string) map[string]string {
+	labelMap := make(map[string]string)
+	for _, label := range labels {
+		if name, value, found := strings.Cut(label, "="); found {
+			labelMap[name] = value
+		}
+	}
+	return labelMap
 }

--- a/tests/operations-clone.robot
+++ b/tests/operations-clone.robot
@@ -27,10 +27,13 @@ Clone Existing Container
     Create Container    app2    docker.io/library/httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app2 --format "{{.Id}}"
 
-    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app2 --force
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-clone --container app2 --force --label io.thin-edge.last_id=${prev_container_id}
 
     ${next_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect app2 --format "{{.Id}}"
     Should Not Be Equal    ${next_container_id}    ${prev_container_id}
+
+    ${label_prev_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect app2 --format '{{ index .Config.Labels "io.thin-edge.last_id" }}'
+    Should Be Equal    ${label_prev_id}    ${prev_container_id}
 
 Clone Existing Container by Timeout Whilst Waiting For Exit
     Create Container    app3    docker.io/library/httpd:2.4


### PR DESCRIPTION
Add flag to allow commands to specify additional labels that should be added to container when launching them. This will help other commands to control where the forked containers should be monitored by the tedge-container-plugin service or not.