### PR TITLE
feat(internal): improvements to internal cli tools

### DIFF
--- a/cli/tools/cmd.go
+++ b/cli/tools/cmd.go
@@ -16,6 +16,7 @@ func NewToolsCommand(cmdCli cli.Cli) *cobra.Command {
 		NewContainerCloneCommand(cmdCli),
 		NewContainerLogsCommand(cmdCli),
 		NewContainerRunInContextCommand(cmdCli),
+		NewContainerRemoveCommand(cmdCli),
 	)
 	return cmd
 }

--- a/cli/tools/container_clone.go
+++ b/cli/tools/container_clone.go
@@ -22,6 +22,7 @@ type ContainerCloneCommand struct {
 	CommandContext cli.Cli
 
 	// Options
+	ForkName       string
 	ForceUpdate    bool
 	Fork           bool
 	WaitForExit    bool
@@ -64,6 +65,7 @@ func NewContainerCloneCommand(ctx cli.Cli) *cobra.Command {
 	cmd.Flags().BoolVar(&command.WaitForExit, "wait-for-exit", false, "Wait for the container to stop/exit before updating")
 	cmd.Flags().BoolVar(&command.CheckForUpdate, "check", false, "Only check if an update is necessary, don't perform the update")
 	cmd.Flags().StringVar(&command.Entrypoint, "entrypoint", "", "Change the container entrypoint when cloning the container")
+	cmd.Flags().StringVar(&command.ForkName, "fork-name", "", "Container name to use for the fork")
 	cmd.Flags().StringSliceVarP(&command.Labels, "label", "l", []string{}, "Set meta data on the new container")
 	cmd.Flags().StringSliceVar(&command.ForkLabels, "fork-label", []string{}, "Set meta data on a the forked container")
 
@@ -208,6 +210,9 @@ func (c *ContainerCloneCommand) RunE(cmd *cobra.Command, args []string) error {
 		slog.Info("Forking container.", "command", strings.Join(forkCmd, " "))
 
 		cloneOptions := container.CloneOptions{
+			// Fork container name. If blank then a random name will be used
+			Name: c.ForkName,
+
 			Cmd: forkCmd,
 
 			// Use the new image, so that fixes can be delivered in the new image

--- a/cli/tools/container_remove.go
+++ b/cli/tools/container_remove.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package tools
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+	"github.com/thin-edge/tedge-container-plugin/pkg/container"
+)
+
+type ContainerRemoveCommand struct {
+	*cobra.Command
+
+	CommandContext cli.Cli
+
+	// Options
+	Tail       string
+	Since      string
+	Until      string
+	Timestamps bool
+	Follow     bool
+	Details    bool
+}
+
+// NewContainerLogsCommand creates a new container remove command
+func NewContainerRemoveCommand(ctx cli.Cli) *cobra.Command {
+	command := &ContainerLogsCommand{
+		CommandContext: ctx,
+	}
+	cmd := &cobra.Command{
+		Use:          "container-remove [OPTIONS] CONTAINER...",
+		Short:        "Remove a container (stopping if necessary)",
+		RunE:         command.RunE,
+		Args:         cobra.ArbitraryArgs,
+		SilenceUsage: true,
+	}
+	command.Command = cmd
+	return cmd
+}
+
+func (c *ContainerRemoveCommand) RunE(cmd *cobra.Command, args []string) error {
+	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
+
+	containerCli, err := container.NewContainerClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	errs := make([]error, 0)
+	for _, name := range args {
+		errs = append(errs, containerCli.StopRemoveContainer(ctx, name))
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,0 +1,24 @@
+package random
+
+import (
+	"math/rand"
+	"time"
+)
+
+const charset = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func StringWithCharset(length int, charset string) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+func String(length int) string {
+	return StringWithCharset(length, charset)
+}


### PR DESCRIPTION
Add options to internal tools to improve the tedge-container-bundle feature set:

* Control container names whilst using `container-clone`
* Allow user to control the container prefix using `run-in-context`
* Add command to stop and remove a container