### PR TITLE
fix(config): update config path reference used by service definitions

### DIFF
--- a/packaging/services/init.d/service.init
+++ b/packaging/services/init.d/service.init
@@ -12,7 +12,7 @@
 [ -f /etc/tedge-container-plugin/env ] && . /etc/tedge-container-plugin/env
 
 dir="/var"
-cmd="/usr/bin/tedge-container run /usr/bin/tedge-container run --config /etc/tedge-container-plugin/config.toml"
+cmd="/usr/bin/tedge-container run /usr/bin/tedge-container run --config /etc/tedge/plugins/tedge-container-plugin.toml"
 user="root"
 
 name=$(basename "$0")

--- a/packaging/services/s6-overlay/tedge-container-plugin/run
+++ b/packaging/services/s6-overlay/tedge-container-plugin/run
@@ -40,10 +40,10 @@ fdmove -c 2 1
 ifte -X
 {
     # then
-    exec sudo -E /usr/bin/tedge-container run --config /etc/tedge-container-plugin/config.toml
+    exec sudo -E /usr/bin/tedge-container run --config /etc/tedge/plugins/tedge-container-plugin.toml
 }
 {
     # else
-    exec /usr/bin/tedge-container run --config /etc/tedge-container-plugin/config.toml
+    exec /usr/bin/tedge-container run --config /etc/tedge/plugins/tedge-container-plugin.toml
 }
 exec which sudo

--- a/packaging/services/systemd/tedge-container-plugin.service
+++ b/packaging/services/systemd/tedge-container-plugin.service
@@ -4,7 +4,7 @@ After=mosquitto.service
 
 [Service]
 EnvironmentFile=-/etc/tedge-container-plugin/env
-ExecStart=/usr/bin/tedge-container run --config /etc/tedge-container-plugin/config.toml
+ExecStart=/usr/bin/tedge-container run --config /etc/tedge/plugins/tedge-container-plugin.toml
 User=root
 Restart=always
 RestartSec=5

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -20,7 +20,7 @@ import (
 	"github.com/thin-edge/tedge-container-plugin/pkg/utils"
 )
 
-var LinuxConfigFilePath = "/etc/tedge-container-plugin/config.toml"
+var LinuxConfigFilePath = "/etc/tedge/plugins/tedge-container-plugin.toml"
 
 func NewExitCodeError(err error) *ExitCodeError {
 	return &ExitCodeError{


### PR DESCRIPTION
Fix configuration path referenced by services to use the updated config file location to `/etc/tedge/plugins/tedge-container-plugin.toml`