### PR TITLE
feat(container-group): improve logging when removing a compose project

### DIFF
--- a/cli/container_group/install.go
+++ b/cli/container_group/install.go
@@ -70,7 +70,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 
 	// Stop project
 	if downFirst {
-		if err := cli.ComposeDown(ctx, stderr, projectName); err != nil {
+		if err := cli.ComposeDown(ctx, stderr, projectName, workingDir); err != nil {
 			slog.Warn("Compose down failed, but continuing anyway.", "err", err)
 		}
 	}

--- a/cli/container_group/remove.go
+++ b/cli/container_group/remove.go
@@ -6,6 +6,7 @@ package container_group
 import (
 	"context"
 	"log/slog"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
@@ -15,29 +16,39 @@ import (
 type RemoveCommand struct {
 	*cobra.Command
 
-	ModuleVersion string
+	CommandContext cli.Cli
+	ModuleVersion  string
 }
 
 // removeCmd represents the remove command
 func NewRemoveCommand(ctx cli.Cli) *cobra.Command {
-	command := &RemoveCommand{}
+	command := &RemoveCommand{
+		CommandContext: ctx,
+	}
 	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove a container",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
-			ctx := context.Background()
-			projectName := args[0]
-
-			cli, err := container.NewContainerClient()
-			if err != nil {
-				return err
-			}
-
-			return cli.ComposeDown(ctx, cmd.ErrOrStderr(), projectName)
-		},
+		RunE:  command.RunE,
 	}
 	cmd.Flags().StringVar(&command.ModuleVersion, "module-version", "", "Software version to remove")
 	return cmd
+}
+
+func (c *RemoveCommand) RunE(cmd *cobra.Command, args []string) error {
+	slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
+	ctx := context.Background()
+	projectName := args[0]
+
+	cli, err := container.NewContainerClient()
+	if err != nil {
+		return err
+	}
+
+	persistentDir, err := c.CommandContext.PersistentDir(false)
+	if err != nil {
+		return err
+	}
+	workingDir := filepath.Join(persistentDir, "compose", projectName)
+	return cli.ComposeDown(ctx, cmd.ErrOrStderr(), projectName, workingDir)
 }


### PR DESCRIPTION
Improve logging on the `container-group` sm-plugin when removing existing compose groups to help diagnose unexpected errors.