### PR TITLE
fix(internal): fix container-remove command and add test

### DIFF
--- a/cli/tools/container_remove.go
+++ b/cli/tools/container_remove.go
@@ -29,7 +29,7 @@ type ContainerRemoveCommand struct {
 
 // NewContainerLogsCommand creates a new container remove command
 func NewContainerRemoveCommand(ctx cli.Cli) *cobra.Command {
-	command := &ContainerLogsCommand{
+	command := &ContainerRemoveCommand{
 		CommandContext: ctx,
 	}
 	cmd := &cobra.Command{

--- a/tests/container-remove.robot
+++ b/tests/container-remove.robot
@@ -1,0 +1,35 @@
+*** Settings ***
+Resource    ./resources/common.robot
+Library    String
+Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
+Suite Setup    Suite Setup
+
+Test Tags    docker    podman
+
+*** Test Cases ***
+
+Remove Container
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker run -d --network bridge --name app30 httpd:2.4.61-alpine
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app30    exp_exit_code=0
+
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app30
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app30    exp_exit_code=!0
+
+Remove Container Non Existent Container Should Not Through An Error
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app31
+
+*** Keywords ***
+
+Suite Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
+
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir /data


### PR DESCRIPTION
Fix a bug where the `tedge-container tools container-remove` command was calling the incorrect command.