### PR TITLE
fix: prune unused images not just dangling

### DIFF
--- a/cli/container/finalize.go
+++ b/cli/container/finalize.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -31,7 +30,7 @@ func NewFinalizeCommand(ctx cli.Cli) *cobra.Command {
 			}
 			slog.Info("Pruning images")
 			ctx := context.Background()
-			resp, err := cli.Client.ImagesPrune(ctx, filters.Args{})
+			resp, err := cli.ImagesPruneUnused(ctx)
 			if err != nil {
 				return err
 			}

--- a/cli/container_group/finalize.go
+++ b/cli/container_group/finalize.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
@@ -31,7 +30,7 @@ func NewFinalizeCommand(ctx cli.Cli) *cobra.Command {
 			}
 			slog.Info("Pruning images")
 			ctx := context.Background()
-			resp, err := cli.Client.ImagesPrune(ctx, filters.Args{})
+			resp, err := cli.ImagesPruneUnused(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1209,6 +1209,14 @@ func (c *ContainerClient) Self(ctx context.Context) (types.ContainerJSON, error)
 	return types.ContainerJSON{}, errdefs.NotFound(fmt.Errorf("could not find container by hostname"))
 }
 
+// Prune both unused and dangling images
+func (c *ContainerClient) ImagesPruneUnused(ctx context.Context) (image.PruneReport, error) {
+	pruneFilters := filters.NewArgs()
+	// Note: dangling=false is the equivalent to docker image prune -a
+	pruneFilters.Add("dangling", strconv.FormatBool(false))
+	return c.Client.ImagesPrune(ctx, pruneFilters)
+}
+
 func (c *ContainerClient) Fork(ctx context.Context, currentContainer types.ContainerJSON, cloneOptions CloneOptions) error {
 	if cloneOptions.Image == "" {
 		cloneOptions.Image = currentContainer.Config.Image

--- a/tests/container-logs.robot
+++ b/tests/container-logs.robot
@@ -12,7 +12,7 @@ Test Tags    docker    podman
 
 Get Container Logs
     # Run dummy container then exit
-    DeviceLibrary.Execute Command    cmd=tedge-container engine docker run --name app10 httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; echo hello inside container stderr >&2;'
+    DeviceLibrary.Execute Command    cmd=tedge-container tools container-remove app10 ||: ; tedge-container engine docker run --name app10 httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; echo hello inside container stderr >&2;'
 
     # Fetch logs
     ${output}=    DeviceLibrary.Execute Command    sudo tedge-container tools container-logs app10

--- a/tests/container-remove.robot
+++ b/tests/container-remove.robot
@@ -11,7 +11,7 @@ Test Tags    docker    podman
 *** Test Cases ***
 
 Remove Container
-    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker run -d --network bridge --name app30 httpd:2.4.61-alpine
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app30 ||: ; sudo tedge-container engine docker run -d --network bridge --name app30 httpd:2.4.61-alpine
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app30    exp_exit_code=0
 
     DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app30


### PR DESCRIPTION
Whilst pruning images using the equivalent to `docker image prune -a` to remove all unused images (not just the dangling ones).