### PR TITLE
fix: exclude oci labels when cloning a container

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1307,7 +1307,8 @@ func CloneContainerConfig(ref *container.Config, opts CloneOptions) *container.C
 		Tty:             ref.Tty,
 		ExposedPorts:    ref.ExposedPorts,
 		Domainname:      ref.Domainname,
-		Labels:          ref.Labels,
+		// Don't copy oci labels as they are included in the image itself
+		Labels: FilterLabels(ref.Labels, []string{"org.opencontainers."}),
 	}
 	if len(opts.Cmd) > 0 {
 		clonedConfig.Cmd = opts.Cmd
@@ -1395,4 +1396,15 @@ func FormatLabels(labels []string) map[string]string {
 		}
 	}
 	return labelMap
+}
+
+func FilterLabels(l map[string]string, exclude []string) map[string]string {
+	filtered := make(map[string]string)
+
+	for k, v := range l {
+		if !strings.HasPrefix(k, "org.opencontainers.") {
+			filtered[k] = v
+		}
+	}
+	return filtered
 }

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -3,6 +3,8 @@ package container
 import (
 	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_ResolveDockerIOImage(t *testing.T) {
@@ -32,6 +34,18 @@ func Test_ResolveDockerIOImage(t *testing.T) {
 		}
 	}
 
+}
+
+func Test_FilterLabels(t *testing.T) {
+	in := map[string]string{
+		"foo":                              "bar",
+		"org.opencontainers.image.authors": "thin-edge.io",
+		"org.opencontainers.image.version": "1.2.3",
+	}
+	out := FilterLabels(in, []string{"org.opencontainers."})
+
+	assert.Len(t, out, 1)
+	assert.Equal(t, out["foo"], "bar")
 }
 
 func Test_PruneIMages(t *testing.T) {


### PR DESCRIPTION
Exclude all oci labels whilst cloning a container (e.g. `org.opencontainers.*`) to avoid overwriting the labels which are included in the new image.