### PR TITLE
feat(container-tools): add a container-restart command

### DIFF
--- a/cli/tools/cmd.go
+++ b/cli/tools/cmd.go
@@ -17,6 +17,7 @@ func NewToolsCommand(cmdCli cli.Cli) *cobra.Command {
 		NewContainerLogsCommand(cmdCli),
 		NewContainerRunInContextCommand(cmdCli),
 		NewContainerRemoveCommand(cmdCli),
+		NewContainerRestartCommand(cmdCli),
 	)
 	return cmd
 }

--- a/cli/tools/container_restart.go
+++ b/cli/tools/container_restart.go
@@ -1,0 +1,64 @@
+/*
+Copyright © 2024 thin-edge.io <info@thin-edge.io>
+*/
+package tools
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/spf13/cobra"
+	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
+	"github.com/thin-edge/tedge-container-plugin/pkg/container"
+)
+
+type ContainerRestartCommand struct {
+	*cobra.Command
+
+	CommandContext cli.Cli
+}
+
+// NewContainerRestartCommand restarts a container
+func NewContainerRestartCommand(ctx cli.Cli) *cobra.Command {
+	command := &ContainerRestartCommand{
+		CommandContext: ctx,
+	}
+	cmd := &cobra.Command{
+		Use:          "container-restart [OPTIONS] [CONTAINER]",
+		Short:        "Restart a container",
+		Long:         "If this command is called with no arguments, then it will try to detect the container that the command is running under (if running inside a container)",
+		RunE:         command.RunE,
+		Args:         cobra.ArbitraryArgs,
+		SilenceUsage: true,
+	}
+
+	command.Command = cmd
+	return cmd
+}
+
+func (c *ContainerRestartCommand) RunE(cmd *cobra.Command, args []string) error {
+	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
+
+	containerCli, err := container.NewContainerClient()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	if len(args) == 0 {
+		slog.Info("Restarting current container")
+		con, err := containerCli.Self(ctx)
+		if err != nil {
+			return err
+		}
+		args = append(args, con.ID)
+	}
+
+	errs := make([]error, 0)
+	for _, con := range args {
+		errs = append(errs, containerCli.RestartContainer(ctx, con))
+	}
+	return errors.Join(errs...)
+}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -393,6 +393,12 @@ func (c *ContainerClient) StopRemoveContainer(ctx context.Context, containerID s
 	return err
 }
 
+// RestartContainer a container
+func (c *ContainerClient) RestartContainer(ctx context.Context, containerID string) error {
+	slog.Info("Restarting container.", "id", containerID)
+	return c.Client.ContainerRestart(ctx, containerID, container.StopOptions{})
+}
+
 func (c *ContainerClient) List(ctx context.Context, options FilterOptions) ([]TedgeContainer, error) {
 	// Filter for docker compose projects
 	listOptions := container.ListOptions{

--- a/tests/container-restart.robot
+++ b/tests/container-restart.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Resource    ./resources/common.robot
+Library    String
+Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
+Suite Setup    Suite Setup
+
+Test Tags    docker    podman
+
+*** Test Cases ***
+
+Restart Container
+    ${started_at_before}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app40 --format "{{ .State.StartedAt }}"
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-restart app40
+    ${started_at_after}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app40 --format "{{ .State.StartedAt }}"
+    Should Not Be Equal As Strings    ${started_at_after}    ${started_at_before}
+
+Restart Unknown Container Fails
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-restart doesNotExist    exp_exit_code=!0
+
+*** Keywords ***
+
+Suite Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
+
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir /data
+
+    # Create a dummy container
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app40 ||: ; sudo tedge-container engine docker run -d --network bridge --name app40 httpd:2.4.61-alpine
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app40    exp_exit_code=0


### PR DESCRIPTION
New command (for internal use only) to support restarting containers. If no container id is provided it will check if the command is being from run inside a container and use that to restart itself (consistent with such other `container-*` helper commands.