### PR TITLE
fix: fix typos in help text and log output

### DIFF
--- a/cli/tools/container_clone.go
+++ b/cli/tools/container_clone.go
@@ -57,7 +57,7 @@ func NewContainerCloneCommand(ctx cli.Cli) *cobra.Command {
 	cmd.Flags().DurationVar(&command.Duration, "duration", 15*time.Second, "How long to wait for the clone container to be healthy")
 	cmd.Flags().DurationVar(&command.StopTimeout, "stop-timeout", 60*time.Second, "Timeout used whilst waiting for container to stop. Only used with --wait-for-exit")
 	cmd.Flags().DurationVar(&command.StopAfter, "stop-after", 10*time.Second, "Timeout container after a delay. Incompatible with --wait-for-exit")
-	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the closed container on exit")
+	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the cloned container on exit")
 	cmd.Flags().StringSliceVar(&command.AddHost, "add-host", []string{}, "Add extra hosts to the container")
 	cmd.Flags().StringSliceVarP(&command.Env, "env", "e", []string{}, "Environment variables to add to the container")
 	cmd.Flags().BoolVar(&command.ForceUpdate, "force", false, "Force an update, disable the image comparison check")

--- a/cli/tools/run_context.go
+++ b/cli/tools/run_context.go
@@ -50,7 +50,7 @@ func NewContainerRunInContextCommand(ctx cli.Cli) *cobra.Command {
 	cmd.Flags().StringVar(&command.Entrypoint, "entrypoint", "", "Overwrite the default ENTRYPOINT of the image")
 	cmd.Flags().StringVar(&command.NamePrefix, "name-prefix", "", "Prefix to be added when generating the name. If left blank then the default will be used")
 	cmd.Flags().StringSliceVarP(&command.Env, "env", "e", []string{}, "Set environment variables")
-	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the closed container on exit")
+	cmd.Flags().BoolVar(&command.AutoRemove, "rm", false, "Auto remove the cloned container on exit")
 	cmd.Flags().StringSliceVarP(&command.Labels, "label", "l", []string{}, "Set meta data on a container")
 
 	command.Command = cmd

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -870,9 +870,9 @@ func (c *ContainerClient) WaitForHealthy(ctx context.Context, containerID string
 			continue
 		}
 
-		// Check if container has a healthcheck command
+		// Check if container has a health check command
 		if con.Config.Healthcheck == nil {
-			slog.Info("Container does not have a healthy script, using state.", "state", con.State.Status, "ok_count", runningCount)
+			slog.Info("Container does not have a health-check script, using state.", "state", con.State.Status, "ok_count", runningCount)
 			if con.State.Running && runningCount > 1 {
 				return nil
 			}


### PR DESCRIPTION
Fix minor typos in the help and log output