### PR TITLE
fix: don't copy host settings when forking a container

### DIFF
--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -48,6 +48,19 @@ func Test_FilterLabels(t *testing.T) {
 	assert.Equal(t, out["foo"], "bar")
 }
 
+func Test_FilterEnvVariables(t *testing.T) {
+	in := []string{
+		"FOO=bar",
+		"BAR=2",
+		"HOSTNAME=bar",
+	}
+	out := FilterEnvVariables(in, []string{"HOSTNAME"})
+
+	assert.Len(t, out, 2)
+	assert.Equal(t, out[0], "FOO=bar")
+	assert.Equal(t, out[1], "BAR=2")
+}
+
 func Test_PruneIMages(t *testing.T) {
 	client, err := NewContainerClient()
 	if err != nil {


### PR DESCRIPTION
Due to some unknown issues in podman 4.4, when a container fork is created and the host config is copied, this causes the podman network iptables rules to be removed when the forked container exits.

By ignoring the copying of the container host config, then the iptables rules seem to be preserved. Anyway, the forked container does not need to have a network to perform its task.