### PR TITLE
dev: rename local build task

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,7 @@ jobs:
           go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
           go install github.com/goreleaser/goreleaser/v2@latest
       - name: Build package (for testing)
-        run: just release-local
+        run: just build-local
 
       #
       # Test

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To build the project use the following steps:
 3. Build the packages
 
     ```sh
-    just release-local
+    just build-local
     ```
 
     The built packages are created under the `./dist` folder.
@@ -188,7 +188,7 @@ To run the tests you will need to have python3 &gt;> 3.9 installed on your syste
 2. Build the software management plugin
 
    ```sh
-   just release-local
+   just build-local
    ```
 
 3. Build the test images

--- a/justfile
+++ b/justfile
@@ -30,8 +30,13 @@ release *ARGS='':
     docker context use default
     goreleaser release --clean --auto-snapshot {{ARGS}}
 
+# install docker buildx and allow multi-arch builds
+build-setup:
+    docker buildx install
+    docker run --privileged --rm tonistiigi/binfmt --install all
+
 # Build a release locally (for testing the release artifacts)
-release-local:
+build-local:
     just -f "{{justfile()}}" release --snapshot
 
 # Install python virtual environment


### PR DESCRIPTION
Rename the `release-local` task to `build-local` to avoid confusion with `just release`