### PR TITLE
feat: try pulling images using podman api directly

### DIFF
--- a/pkg/container/socket_client.go
+++ b/pkg/container/socket_client.go
@@ -3,12 +3,17 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types/image"
+	"github.com/google/go-querystring/query"
 )
 
 type ResponsePruneImage struct {
@@ -19,6 +24,10 @@ type ResponsePruneImage struct {
 type SocketClient struct {
 	BaseURL string
 	Client  *http.Client
+}
+
+func NewDefaultLibPodHTTPClient() *SocketClient {
+	return NewLibPodHTTPClient(findContainerEngineSocket())
 }
 
 func NewLibPodHTTPClient(sock string) *SocketClient {
@@ -38,6 +47,19 @@ func NewLibPodHTTPClient(sock string) *SocketClient {
 
 func (c *SocketClient) resolveURL(path string) string {
 	return strings.Join([]string{c.BaseURL, strings.TrimPrefix(path, "/")}, "/")
+}
+
+var ErrPodmanAPIError = errors.New("podman api not available")
+
+func (c *SocketClient) Test(ctx context.Context) error {
+	r, err := c.Client.Get(c.resolveURL("info"))
+	if err != nil {
+		return err
+	}
+	if r.StatusCode != 200 {
+		return ErrPodmanAPIError
+	}
+	return nil
 }
 
 // Prune all images and return object in same format as the docker prune response
@@ -68,4 +90,69 @@ func (c *SocketClient) PruneImages(body io.Reader) (report image.PruneReport, er
 	}
 	report.SpaceReclaimed = spaceReclaimed
 	return
+}
+
+type PodmanAPIPullOptions struct {
+	AllTags   *bool  `url:"allTags,omitempty"`
+	Quiet     *bool  `url:"quiet,omitempty"`
+	Policy    string `url:"policy,omitempty"`
+	Reference string `url:"reference"`
+}
+
+func (po *PodmanAPIPullOptions) WithPolicy(v string) *PodmanAPIPullOptions {
+	po.Policy = v
+	return po
+}
+
+func (po *PodmanAPIPullOptions) WithAllTags(v bool) *PodmanAPIPullOptions {
+	po.AllTags = &v
+	return po
+}
+
+func (po *PodmanAPIPullOptions) WithQuiet(v bool) *PodmanAPIPullOptions {
+	po.Quiet = &v
+	return po
+}
+
+type PodmanPullOptions struct {
+	image.PullOptions
+
+	Quiet bool
+}
+
+func (c *SocketClient) PullImages(ctx context.Context, imageRef string, alwaysPull bool, pullOptions PodmanPullOptions) error {
+	options := PodmanAPIPullOptions{
+		Reference: imageRef,
+	}
+	options.WithQuiet(pullOptions.Quiet)
+	if alwaysPull {
+		options.WithPolicy("always")
+	}
+
+	queryParams, err := query.Values(options)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.resolveURL(fmt.Sprintf("images/pull?%s", queryParams.Encode())), nil)
+	if err != nil {
+		return err
+	}
+
+	if pullOptions.RegistryAuth != "" {
+		req.Header.Set("X-Registry-Auth", pullOptions.RegistryAuth)
+	}
+
+	r, err := c.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer r.Body.Close()
+	if _, ioErr := io.Copy(os.Stderr, r.Body); ioErr != nil {
+		slog.Warn("Could not write to stderr.", "err", ioErr)
+	}
+
+	slog.Info("Podman API response was successful.", "status", r.Status)
+	return nil
 }


### PR DESCRIPTION
Due to a podman issue (experienced in podman 4.4), sometimes doing a `docker pull` fails for the following reason:

```
write /dev/stderr: input/output error
```

The PR adds logic to attempt to do a manual `podman pull` (via API) which does not seem to suffer the same problem.

This bug is most likely fixed in newer versions of podman (e.g. 5.x), though it is difficult for some users to update the podman versions.