### PR TITLE
fix(sysvinit): fix service start command

### DIFF
--- a/packaging/services/init.d/service.init
+++ b/packaging/services/init.d/service.init
@@ -12,7 +12,7 @@
 [ -f /etc/tedge-container-plugin/env ] && . /etc/tedge-container-plugin/env
 
 dir="/var"
-cmd="/usr/bin/tedge-container run /usr/bin/tedge-container run --config /etc/tedge/plugins/tedge-container-plugin.toml"
+cmd="/usr/bin/tedge-container run --config /etc/tedge/plugins/tedge-container-plugin.toml"
 user="root"
 
 name=$(basename "$0")


### PR DESCRIPTION
Fix the command used to start the sysvinit service where the binary command was just duplicated (copy/paste error).

The bug was spotted by @zhongys-c8y in https://github.com/thin-edge/tedge-container-plugin/issues/134 (though the ticket is otherwise unrelated).