### PR TITLE
feat(experimental): add openrc service definitions to apk package

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -153,6 +153,25 @@ nfpms:
         dst: /etc/s6-overlay/s6-rc.d
         packager: apk
 
+      # OpenRC
+      # Note: symlinks will be created linking the services during the post install script
+      # if openrc is detected
+      - src: ./packaging/services/openrc/tedge-container-plugin.init
+        dst: /usr/share/tedge-container-plugin/services/openrc/init.d/tedge-container-plugin
+        file_info:
+          mode: 0755
+          owner: root
+          group: root
+        packager: apk
+
+      - src: ./packaging/services/openrc/tedge-container-plugin.conf
+        dst: /usr/share/tedge-container-plugin/services/openrc/conf.d/tedge-container-plugin
+        file_info:
+          mode: 0644
+          owner: root
+          group: root
+        packager: apk
+
       # Completions
       - src: ./output/completions.bash
         dst: /etc/bash_completion.d/tedge-container

--- a/packaging/scripts/post-install
+++ b/packaging/scripts/post-install
@@ -39,14 +39,25 @@ cleanInstall() {
 
     # Step 3 (clean install), enable the service in the proper way for this platform
     if [ "${use_systemctl}" = "False" ]; then
-        printf "\033[32m Installing init.d/open-rc service\033[0m\n"
+        if command -V rc-service >/dev/null 2>&1; then
+            # OpenRC
+            printf "\033[32m Installing open-rc service\033[0m\n"
 
-        if command -V chkconfig >/dev/null 2>&1; then
-            chkconfig --add "$SERVICE_NAME"
+            ln -sf /usr/share/tedge-container-plugin/services/openrc/init.d/tedge-container-plugin /etc/init.d/tedge-container-plugin ||:
+            ln -sf /usr/share/tedge-container-plugin/services/openrc/conf.d/tedge-container-plugin /etc/conf.d/tedge-container-plugin ||:
+
+            rc-update add "$SERVICE_NAME" ||:
+            rc-service "$SERVICE_NAME" restart ||:
+        else
+            # SysVInit
+            printf "\033[32m Installing init.d service\033[0m\n"
+            if command -V chkconfig >/dev/null 2>&1; then
+                chkconfig --add "$SERVICE_NAME"
+            fi
+            service "$SERVICE_NAME" restart ||:
         fi
-
-        service "$SERVICE_NAME" restart ||:
     else
+        # SystemD
         printf "\033[32m Installing systemd service\033[0m\n"
         # rhel/centos7 cannot use ExecStartPre=+ to specify the pre start should be run as root
         # even if you want your service to run as non root.

--- a/packaging/scripts/post-remove
+++ b/packaging/scripts/post-remove
@@ -11,10 +11,19 @@ remove() {
     fi
 
     if [ -x "/usr/bin/deb-systemd-helper" ]; then
+        # SystemD (debian)
         deb-systemd-helper purge "${SERVICE_NAME}.service" >/dev/null
         deb-systemd-helper unmask "${SERVICE_NAME}.service" >/dev/null
     elif command -V systemctl >/dev/null 2>&1; then
+        # SystemD (native)
         systemctl unmask "${SERVICE_NAME}.service" >/dev/null
+    elif command -V rc-service >/dev/null 2>&1; then
+        # OpenRC
+        rc-update delete "$SERVICE_NAME" ||:
+        rc-service "$SERVICE_NAME" stop ||:
+
+        rm -f /etc/init.d/tedge-container-plugin
+        rm -f /etc/conf.d/tedge-container-plugin
     fi
 }
 

--- a/packaging/services/openrc/tedge-container-plugin.conf
+++ b/packaging/services/openrc/tedge-container-plugin.conf
@@ -1,0 +1,11 @@
+# Configuration file for /etc/init.d/tedge-container-plugin
+
+# Additional arguments to pass to /usr/bin/tedge-container
+#command_args=
+
+# Overwrite user
+#command_user=root
+
+# Comment out if you don't want to use the supervisor
+supervisor="supervise-daemon"
+respawn_delay=5

--- a/packaging/services/openrc/tedge-container-plugin.init
+++ b/packaging/services/openrc/tedge-container-plugin.init
@@ -1,0 +1,18 @@
+#!/sbin/openrc-run
+description="thin-edge.io container monitor"
+command="/usr/bin/tedge-container"
+: ${command_args=run --config /etc/tedge/plugins/tedge-container-plugin.toml}
+: ${command_user=root}
+: ${supervise_daemon_args=}
+
+pidfile="/run/lock/${RC_SVCNAME}.lock"
+error_log="${LOGFILE:-/var/log/${RC_SVCNAME}.log}"
+
+start_pre()
+{
+    checkpath --file --owner "root" "$error_log"
+}
+
+depend() {
+    after net
+}

--- a/test-images/alpine-openrc-podman-cli/Dockerfile
+++ b/test-images/alpine-openrc-podman-cli/Dockerfile
@@ -1,0 +1,49 @@
+FROM docker.io/alpine:latest
+ARG TARGETPLATFORM
+
+RUN apk add --no-cache \
+        openrc \
+        mdevd-openrc \
+        wget \
+        curl \
+        bash \
+        sudo \
+        jq \
+        dasel \
+        podman \
+        podman-compose \
+        # Required when running inside docker
+        # see https://github.com/containers/buildah/issues/3666
+        fuse-overlayfs \
+    && wget -O - thin-edge.io/install.sh | sh -s \
+    && apk add tedge-command-plugin
+
+ADD https://raw.githubusercontent.com/thin-edge/tedge-demo-container/refs/heads/main/images/common/bootstrap.sh /usr/bin/
+RUN chmod 755 /usr/bin/bootstrap.sh
+
+RUN sed -i '/getty/d' /etc/inittab \
+    && sed -i 's/#mount_program/mount_program/' /etc/containers/storage.conf
+
+COPY dist/*.apk /tmp/
+RUN case ${TARGETPLATFORM} in \
+        "linux/386")  PKG_ARCH=linux_386  ;; \
+        "linux/amd64")  PKG_ARCH=linux_amd64  ;; \
+        "linux/arm64")  PKG_ARCH=linux_arm64  ;; \
+        "linux/arm/v6")  PKG_ARCH=linux_armv6  ;; \
+        "linux/arm/v7")  PKG_ARCH=linux_armv7  ;; \
+        *) echo "Unsupported target platform: TARGETPLATFORM=$TARGETPLATFORM"; exit 1 ;; \
+    esac \
+    && apk add --allow-untrusted /tmp/*${PKG_ARCH}*.apk \
+    && mkdir -p /opt/packages \
+    && cp /tmp/*${PKG_ARCH}*.apk /opt/packages/ \
+    && rm -f /tmp/*.apk
+
+RUN echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge-container" | tee /etc/sudoers.d/tedge-containers \
+    && mkdir -p /etc/tedge-container-plugin \
+    && dasel put -r toml -t string -v '60s' 'metrics.interval' --indent 0 < /etc/tedge/plugins/tedge-container-plugin.toml > /etc/tedge/plugins/tedge-container-plugin.toml.tmp \
+    && mv /etc/tedge/plugins/tedge-container-plugin.toml.tmp /etc/tedge/plugins/tedge-container-plugin.toml
+
+# Default services
+RUN rc-update add podman
+
+CMD ["/sbin/init"]

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -162,7 +162,7 @@ Collect Logs
     Collect Systemd Logs
 
 Collect Systemd Logs
-    Execute Command    sudo journalctl -n 10000
+    Execute Command    sudo journalctl -n 10000 || head -n 10000 /var/log/*.log
 
 Collect Workflow Logs
     Execute Command    cat /var/log/tedge/agent/*


### PR DESCRIPTION
Add OpenRC service definitions to the Alpine Linux package (.apk). The files will only be used if OpenRC is detected during installation time.

The feature is still marked as experimental as the system tests setup needs to be updated to support an Alpine Linux based image and there seems to be some problems getting podman to be functional within the system test container.

This is purely a packaging change and no other functional changes are included