### PR TITLE
fix(packaging): make sysvinit service definition executable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,7 +135,7 @@ nfpms:
       - src: ./packaging/services/init.d/service.init
         dst: /etc/init.d/tedge-container-plugin
         file_info:
-          mode: 0644
+          mode: 0755
           owner: tedge
           group: tedge
         packager: deb


### PR DESCRIPTION
Fix problem with the sysvinit service definition where it was not configured to be executable (e.g. chmod 755)