### PR TITLE
tests: use common log collection keyword

### DIFF
--- a/tests/installation.robot
+++ b/tests/installation.robot
@@ -34,13 +34,3 @@ Test Setup
     # Install older version
     DeviceLibrary.Execute Command   apt-get update && apt-get install -y tedge-container-plugin
     Cumulocity.Should Have Services    name=tedge-container-monitor    service_type=service    min_count=1    max_count=1    timeout=60
-
-Collect Logs
-    Collect Workflow Logs
-    Collect Systemd Logs
-
-Collect Systemd Logs
-    Execute Command    sudo journalctl -n 10000
-
-Collect Workflow Logs
-    Execute Command    cat /var/log/tedge/agent/*

--- a/tests/operations-clone.robot
+++ b/tests/operations-clone.robot
@@ -91,13 +91,3 @@ Create Container
     ${operation}=    Cumulocity.Install Software    {"name": "${name}", "version": "${image}", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Device Should Have Installed Software    {"name": "${name}", "version": "${image}", "softwareType": "container"}
-
-Collect Logs
-    Collect Workflow Logs
-    Collect Systemd Logs
-
-Collect Systemd Logs
-    Execute Command    sudo journalctl -n 10000
-
-Collect Workflow Logs
-    Execute Command    cat /var/log/tedge/agent/*

--- a/tests/operations-private-registries.robot
+++ b/tests/operations-private-registries.robot
@@ -86,14 +86,3 @@ Install container-group file
     ${binary_url}=    Cumulocity.Create Inventory Binary    ${package_name}    container-group    file=${file}
     ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=300
-
-
-Collect Logs
-    Collect Workflow Logs
-    Collect Systemd Logs
-
-Collect Systemd Logs
-    Execute Command    sudo journalctl -n 10000
-
-Collect Workflow Logs
-    Execute Command    cat /var/log/tedge/agent/*

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -156,13 +156,3 @@ Install container-group file
     Operation Should Be SUCCESSFUL    ${operation}
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    My Custom Web Application
     Cumulocity.Should Have Services    name=${package_name}@${service_name}    service_type=container-group    status=up
-
-Collect Logs
-    Collect Workflow Logs
-    Collect Systemd Logs
-
-Collect Systemd Logs
-    Execute Command    sudo journalctl -n 10000 || head -n 10000 /var/log/*.log
-
-Collect Workflow Logs
-    Execute Command    cat /var/log/tedge/agent/*

--- a/tests/resources/common.robot
+++ b/tests/resources/common.robot
@@ -1,3 +1,6 @@
+*** Settings ***
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
 *** Variables ***
 
 # Cumulocity settings
@@ -6,3 +9,15 @@
 # Docker adapter settings (to control which image is used in the system tests).
 # The user just needs to set the TEST_IMAGE env variable
 &{DOCKER_CONFIG}    image=%{TEST_IMAGE=}
+
+*** Keywords ***
+
+Collect Logs
+    Collect Workflow Logs
+    Collect Systemd Logs
+
+Collect Systemd Logs
+    Execute Command    if command -V journalctl >/dev/null 2>&1; then sudo journalctl -n 10000 | grep -v -e ' kernel: audit:'; else head -n 10000 /var/log/*.log; fi
+
+Collect Workflow Logs
+    Execute Command    cat /var/log/tedge/agent/*

--- a/tests/self.robot
+++ b/tests/self.robot
@@ -32,13 +32,3 @@ Suite Setup
 
     # Create data directory
     DeviceLibrary.Execute Command    mkdir /data
-
-Collect Logs
-    Collect Workflow Logs
-    Collect Systemd Logs
-
-Collect Systemd Logs
-    Execute Command    sudo journalctl -n 10000
-
-Collect Workflow Logs
-    Execute Command    cat /var/log/tedge/agent/*


### PR DESCRIPTION
Define a log collection keyword in the common resource so it can be reused in all tests.

The log collection now ignores common kernel audit messages in an effort to reduce the noise within the collected logs.