### PR TITLE
refactor: use tedge entity store api for registration

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,6 +85,17 @@ nfpms:
       - rpm
       - apk
 
+    overrides:
+      # Dependency on the Entity HTTP API which was only added in tedge >= 1.5.0
+      # Note: Don't add explicit dependency for apk (Alpine Linux)
+      # as generally only the tedge is just installed via a binary and not the apk package
+      deb:
+        dependencies:
+          - tedge (>= 1.5.0)
+      rpm:
+        dependencies:
+          - tedge >= 1.5.0-1
+
     # FIXME: Remove for official release, as the package can be called "tedge-container-plugin" instead of "tedge-container-plugin-ng"
     replaces:
       - tedge-container-plugin

--- a/cli/run/cmd.go
+++ b/cli/run/cmd.go
@@ -50,6 +50,8 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 				DeleteFromCloud:    cliContext.DeleteFromCloud(),
 				EnableEngineEvents: cliContext.EngineEventsEnabled(),
 
+				HTTPHost:       cliContext.GetHTTPHost(),
+				HTTPPort:       cliContext.GetHTTPPort(),
 				MQTTHost:       cliContext.GetMQTTHost(),
 				MQTTPort:       cliContext.GetMQTTPort(),
 				CumulocityHost: cliContext.GetCumulocityHost(),
@@ -158,6 +160,8 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 	viper.SetDefault("delete_from_cloud.enabled", true)
 
 	// thin-edge.io services
+	viper.SetDefault("client.http.host", "127.0.0.1")
+	viper.SetDefault("client.http.port", 8000)
 	viper.SetDefault("client.mqtt.host", "127.0.0.1")
 	// client.mqtt.port: 0 = auto-detection, where 8883 is used when the cert files exist, or 1883 otherwise
 	viper.SetDefault("client.mqtt.port", 0)

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -30,6 +30,11 @@ labels = [ "tedge.ignore" ]
 key = "/etc/tedge/device-certs/local-tedge.key"
 # Certificate file used to connect to local thin-edge.io services (only used if the file exists)
 cert_file = "/etc/tedge/device-certs/local-tedge.crt"
+  [client.http]
+  # thin-edge.io HTTP host operated by the tedge-agent on the main device
+  host = "127.0.0.1"
+  # thin-edge.io HTTP port operated by the tedge-agent on the main device
+  port = 8000
 
   [client.mqtt]
   # thin-edge.io MQTT host

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -155,6 +155,18 @@ func (c *Cli) DeleteFromCloud() bool {
 	return viper.GetBool("delete_from_cloud.enabled")
 }
 
+func (c *Cli) GetHTTPHost() string {
+	return viper.GetString("client.http.host")
+}
+
+func (c *Cli) GetHTTPPort() uint16 {
+	v := viper.GetUint16("client.http.port")
+	if v == 0 {
+		return 8000
+	}
+	return v
+}
+
 func (c *Cli) GetMQTTHost() string {
 	return viper.GetString("client.mqtt.host")
 }

--- a/pkg/tedge/target.go
+++ b/pkg/tedge/target.go
@@ -5,10 +5,14 @@ import (
 	"strings"
 )
 
+var EntityTypeService = "service"
+var EntityTypeChildDevice = "child-device"
+
 type Target struct {
 	RootPrefix    string
 	TopicID       string
 	CloudIdentity string
+	Name          string
 }
 
 func (t *Target) ExternalID() string {
@@ -25,6 +29,7 @@ func (t *Target) Topic() string {
 func (t *Target) Service(name string) *Target {
 	target := NewTarget(t.RootPrefix, strings.Join(strings.Split(t.TopicID, "/")[0:2], "/")+"/service/"+name)
 	target.CloudIdentity = t.CloudIdentity
+	target.Name = name
 	return target
 }
 

--- a/pkg/tedge/tedge.go
+++ b/pkg/tedge/tedge.go
@@ -1,6 +1,7 @@
 package tedge
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -10,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,6 +50,7 @@ type Client struct {
 	Client           mqtt.Client
 	Target           Target
 	CumulocityClient *c8y.Client
+	TedgeAPI         *TedgeAPIClient
 
 	Entities map[string]any
 	mutex    sync.RWMutex
@@ -103,6 +106,9 @@ func NewTLSConfig(keyFile string, certFile string, caFile string) *tls.Config {
 }
 
 type ClientConfig struct {
+	HTTPHost string
+	HTTPPort uint16
+
 	MqttHost string
 	MqttPort uint16
 
@@ -155,35 +161,20 @@ func NewClient(parent Target, target Target, serviceName string, config *ClientC
 	opts.SetOnConnectHandler(func(c mqtt.Client) {
 		slog.Info("MQTT Client is connected")
 
-		payload, err := PayloadRegistration(map[string]any{}, serviceName, "service", parent.TopicID)
-		if err != nil {
-			slog.Error("Could not convert payload.", "err", err)
-			return
-		}
-		tok := c.Publish(GetTopicRegistration(target), 1, true, payload)
-		<-tok.Done()
-		if err := tok.Error(); err != nil {
-			slog.Error("Failed to publish registration topic.", "err", err)
-			return
-		}
-		slog.Info("Registered service", "topic", GetTopicRegistration(target))
-
 		// Configure subscriptions
 		subscriptions := make(map[string]byte)
 		subscriptions[target.RootPrefix+"/+/+/+/+"] = 1
 		subscriptions[GetTopic(*target.Service("+"), "cmd", "health", "check")] = 1
 		slog.Info("Subscribing to topics.", "topics", subscriptions)
-		tok = c.SubscribeMultiple(subscriptions, nil)
+		tok := c.SubscribeMultiple(subscriptions, nil)
 		tok.Wait()
 
-		// Delay before publishing health status
-		// FIXME: This can be removed once thin-edge.io supports a registration API
-		time.Sleep(1000 * time.Millisecond)
-		payload, err = PayloadHealthStatus(map[string]any{}, StatusUp)
+		payload, err := PayloadHealthStatus(map[string]any{}, StatusUp)
 		if err != nil {
 			return
 		}
 		topic := GetHealthTopic(target)
+		slog.Info("Updating health topic.", "topic", topic)
 		tok = c.Publish(topic, 1, true, payload)
 		<-tok.Done()
 		if err := tok.Error(); err != nil {
@@ -204,6 +195,7 @@ func NewClient(parent Target, target Target, serviceName string, config *ClientC
 		Parent:           parent,
 		Target:           target,
 		CumulocityClient: c8yclient,
+		TedgeAPI:         NewTedgeAPIClient(useCerts, config),
 		Entities:         make(map[string]any),
 	}
 
@@ -263,6 +255,7 @@ func (c *Client) DeleteCumulocityManagedObject(target Target) (bool, error) {
 
 // Publish an MQTT message
 func (c *Client) Publish(topic string, qos byte, retained bool, payload any) error {
+	slog.Info("Publishing MQTT Message.", "topic", topic, "payload", payload, "qos", qos, "retained", retained)
 	tok := c.Client.Publish(topic, 1, retained, payload)
 	if !tok.WaitTimeout(100 * time.Millisecond) {
 		return fmt.Errorf("timed out")
@@ -273,25 +266,8 @@ func (c *Client) Publish(topic string, qos byte, retained bool, payload any) err
 // Deregister a thin-edge.io entity
 // Clear the status health topic as well as the registration topic
 func (c *Client) DeregisterEntity(target Target, retainedTopicPartials ...string) error {
-	delay := 500 * time.Millisecond
-	// Clear any additional topics with retained messages before deregistering
-	for _, topicPartial := range retainedTopicPartials {
-		if err := c.Publish(GetTopic(target, topicPartial), 1, true, ""); err != nil {
-			return err
-		}
-		time.Sleep(delay)
-	}
-
-	if err := c.Publish(GetTopic(target, "status", "health"), 1, true, ""); err != nil {
-		return err
-	}
-	time.Sleep(delay)
-
-	if err := c.Publish(GetTopic(target), 1, true, ""); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := c.TedgeAPI.DeleteEntity(context.Background(), target)
+	return err
 }
 
 // Get the thin-edge.io entities that have already been registered (as retained messages)
@@ -299,4 +275,183 @@ func (c *Client) GetEntities() (map[string]any, error) {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 	return c.Entities, nil
+}
+
+type TedgeAPIClient struct {
+	Client  *http.Client
+	BaseURL string
+}
+
+func NewTedgeAPIClient(useCerts bool, config *ClientConfig) *TedgeAPIClient {
+	tr := &http.Transport{
+		TLSClientConfig: nil,
+	}
+
+	if useCerts {
+		tr = &http.Transport{
+			TLSClientConfig: NewTLSConfig(config.KeyFile, config.CertFile, config.CAFile),
+		}
+	}
+	client := &http.Client{
+		Transport: tr,
+	}
+
+	scheme := "http"
+	if useCerts {
+		scheme = "https"
+	}
+	baseURL := fmt.Sprintf("%s://%s:%d", scheme, config.HTTPHost, config.HTTPPort)
+
+	return &TedgeAPIClient{
+		Client:  client,
+		BaseURL: baseURL,
+	}
+}
+
+type Entity struct {
+	TedgeID       string `json:"@id,omitempty"`
+	TedgeType     string `json:"@type,omitempty"`
+	TedgeTopicID  string `json:"@topic-id,omitempty"`
+	TedgeParentID string `json:"@parent,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Type          string `json:"type,omitempty"`
+}
+
+func (c *TedgeAPIClient) GetURL(partials ...string) string {
+	parts := make([]string, 0, 1+len(partials))
+	parts = append(parts, c.BaseURL)
+	parts = append(parts, partials...)
+	return strings.Join(parts, "/")
+}
+
+func (c *TedgeAPIClient) CreateEntity(ctx context.Context, entity Entity) (*Response, error) {
+	b, err := json.Marshal(entity)
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("Registering device by http api.", "body", b)
+	reqURL := c.GetURL("te/v1/entities")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.Do(req)
+	return resp, err
+}
+
+func (c *TedgeAPIClient) PatchEntity(ctx context.Context, entity Entity, data any) (*Response, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("Patching entity by http api.", "body", b)
+	reqURL := c.GetURL("te/v1/entities", entity.TedgeTopicID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, reqURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.Do(req)
+	return resp, err
+}
+
+func (c *TedgeAPIClient) UpdateTwin(ctx context.Context, entity Entity, name string, data any) (*Response, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	slog.Info("Updating twin by http api.", "body", b)
+	reqURL := c.GetURL("te/v1/entities", entity.TedgeTopicID, "twin", name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.Do(req)
+	return resp, err
+}
+
+var ErrNotFound = errors.New("not found")
+var ErrConflict = errors.New("conflict")
+
+func CheckResponse(r *Response, conflictOk bool) (*Response, error) {
+	if r.IsSuccess() {
+		return r, nil
+	}
+
+	var err error
+	switch statusCode := r.StatusCode(); statusCode {
+	case 404:
+		err = fmt.Errorf("api request failed. %w", ErrNotFound)
+	case 409:
+		if !conflictOk {
+			err = fmt.Errorf("api request failed. %w", ErrConflict)
+		}
+	default:
+		err = fmt.Errorf("api request failed. status=%d", statusCode)
+	}
+	return r, err
+}
+
+func (c *TedgeAPIClient) Do(req *http.Request) (*Response, error) {
+	resp, err := c.Client.Do(req)
+	wrappedResponse := NewResponse(resp)
+	if err == nil && wrappedResponse.IsError() {
+		err = fmt.Errorf("api request failed. status=%d", wrappedResponse.StatusCode())
+	}
+	return wrappedResponse, err
+}
+
+func (c *TedgeAPIClient) DeleteEntity(ctx context.Context, target Target) (*Response, error) {
+	reqURL := c.GetURL("te/v1/entities", target.TopicID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.Do(req)
+	CheckResponse(resp, false)
+	return resp, err
+}
+
+func (c *TedgeAPIClient) GetEntity(ctx context.Context, target Target) (*Response, error) {
+	reqURL := c.GetURL("te/v1/entities", target.TopicID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.Do(req)
+	return resp, err
+}
+
+type Response struct {
+	RawResponse *http.Response
+}
+
+func NewResponse(r *http.Response) *Response {
+	return &Response{
+		RawResponse: r,
+	}
+}
+
+// IsSuccess method returns true if HTTP status `code >= 200 and <= 299` otherwise false.
+func (r *Response) IsSuccess() bool {
+	return r.StatusCode() > 199 && r.StatusCode() < 300
+}
+
+// IsError method returns true if HTTP status `code >= 400` otherwise false.
+func (r *Response) IsError() bool {
+	return r.StatusCode() > 399
+}
+
+func (r *Response) StatusCode() int {
+	if r.RawResponse == nil {
+		return 0
+	}
+	return r.RawResponse.StatusCode
 }


### PR DESCRIPTION
Refactor to use the new thin-edge.io [REST API for Entity Management](https://thin-edge.github.io/thin-edge.io/operate/registration/register/) which allows the service entities to be registered and deregistered more easily by sending a single HTTP request and all of the related topics are cleanly removed (rather than having to subscribe to the different topics manually).

Since this change relies on having tedge >= 1.5.0 installed, an explicit dependency has been added to the deb and rpm packages (but not the Alpine Linux packages due to how the tedge container image does not have the tedge apk package installed, just the binaries).