### PR TITLE
test: use latest alpine image in test app

### DIFF
--- a/tests/data/apps/app3/Dockerfile
+++ b/tests/data/apps/app3/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/alpine:3.18
+FROM docker.io/library/alpine:latest
 ENTRYPOINT [ "/bin/sleep", "infinity" ]


### PR DESCRIPTION
Use the alpine:latest image by default for the apps used in system tests (to reduce overhead of having to manually update the tag over time)