### PR TITLE
fix: entity store api

### DIFF
--- a/pkg/tedge/tedge.go
+++ b/pkg/tedge/tedge.go
@@ -319,7 +319,8 @@ type Responder func(*Response, error) (*Response, error)
 func OkResponder(allowedCodes ...int) Responder {
 	return func(r *Response, err error) (*Response, error) {
 		if r.IsError() {
-			if !slices.Contains(allowedCodes, r.StatusCode()) {
+			if slices.Contains(allowedCodes, r.StatusCode()) {
+				slog.Debug("Ok response.", "status_code", r.StatusCode(), "ok_status_codes", allowedCodes)
 				return r, nil
 			}
 			return r, fmt.Errorf("invalid api response. status_code=%d", r.StatusCode())


### PR DESCRIPTION
Fix some errors in loading the entity store api

* use the entity store HTTP api to get a list of the entities instead of using MQTT
* fix an inversion logic when checking the response from the entity store HTTP api
* Add workaround to manually clear the MQTT health status message as the entity store HTTP api does not seem to remove when deregistering a device

Related issues:
* https://github.com/thin-edge/tedge-container-plugin/issues/145