### PR TITLE
feat: delete orphaned services from previously created containers

### DIFF
--- a/cli/run/cmd.go
+++ b/cli/run/cmd.go
@@ -48,6 +48,7 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 				ServiceName:        cliContext.GetServiceName(),
 				EnableMetrics:      cliContext.MetricsEnabled(),
 				DeleteFromCloud:    cliContext.DeleteFromCloud(),
+				DeleteOrphans:      cliContext.DeleteOrphans(),
 				EnableEngineEvents: cliContext.EngineEventsEnabled(),
 
 				HTTPHost:       cliContext.GetHTTPHost(),
@@ -158,6 +159,7 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 	// Feature flags
 	viper.SetDefault("events.enabled", true)
 	viper.SetDefault("delete_from_cloud.enabled", true)
+	viper.SetDefault("delete_from_cloud.orphans", true)
 
 	// thin-edge.io services
 	viper.SetDefault("client.http.host", "127.0.0.1")

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -72,6 +72,8 @@ enabled = true
 [delete_from_cloud]
 # Enable/Disable the deletion of services from the cloud (using REST API) when a container is removed
 enabled = true
+# delete orphaned services (related to containers) from the cloud
+orphans = true
 
 [registry]
 # Path to the file containing container registry credentials

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -155,6 +155,10 @@ func (c *Cli) DeleteFromCloud() bool {
 	return viper.GetBool("delete_from_cloud.enabled")
 }
 
+func (c *Cli) DeleteOrphans() bool {
+	return viper.GetBool("delete_from_cloud.orphans")
+}
+
 func (c *Cli) GetHTTPHost() string {
 	return viper.GetString("client.http.host")
 }


### PR DESCRIPTION
Support removing any orphaned services from the cloud which were previously created with the `container` or `container-group` service type and no longer have any thin-edge.io related entity registered.

This function is only enabled if both settings are true:

* `delete_from_cloud.enabled`
* `delete_from_cloud.orphans`