### PR TITLE
fix: fix env variable filter which would ignore the exclude patterns

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1467,7 +1467,7 @@ func FilterEnvVariables(l []string, exclude []string) []string {
 		ignore := false
 		for _, excludePattern := range exclude {
 			if strings.HasPrefix(envItem, excludePattern) {
-				ignore = false
+				ignore = true
 				break
 			}
 		}


### PR DESCRIPTION
Fix small logic error which led to the env variable filter ignoring the exclusion filters.