### PR TITLE
fix(packaging): set the config type when building the linux package

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -121,6 +121,7 @@ nfpms:
       # Config
       - src: ./packaging/config.toml
         dst: /etc/tedge/plugins/tedge-container-plugin.toml
+        type: config
         file_info:
           mode: 0644
           owner: tedge

--- a/README.md
+++ b/README.md
@@ -97,13 +97,13 @@ Checkout the [TELEMETRY](./docs/TELEMETRY.md) docs for details on what is includ
 
 The tedge-container-plugin can be configured with the following properties.
 
-A default configuration is provided in the package, [tedge-container-plugin/config.toml](./packaging/config.toml) and it include a description of each property.
+A default configuration is provided in the package, [tedge-container-plugin.toml](./packaging/config.toml) and it include a description of each property.
 
 
 **Default Configuration file location**
 
 ```sh
-/etc/tedge-container-plugin/config.toml
+/etc/tedge/plugins/tedge-container-plugin.toml
 ```
 
 **Note**


### PR DESCRIPTION
The `tedge-container-plugin.toml` file wasn't marked as a "config" in the linux packaging definition when meant it would be overridden when upgrading the package.