### PR TITLE
fix: preserve OpenRC conf file on package updates

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -178,6 +178,7 @@ nfpms:
 
       - src: ./packaging/services/openrc/tedge-container-plugin.conf
         dst: /usr/share/tedge-container-plugin/services/openrc/conf.d/tedge-container-plugin
+        type: config
         file_info:
           mode: 0644
           owner: root

--- a/packaging/services/openrc/tedge-container-plugin.conf
+++ b/packaging/services/openrc/tedge-container-plugin.conf
@@ -4,7 +4,7 @@
 #command_args=
 
 # Overwrite user
-#command_user=root
+#command_user="root"
 
 # Comment out if you don't want to use the supervisor
 supervisor="supervise-daemon"


### PR DESCRIPTION
Fix the Alpine Linux packaging of the OpenRC service configuration where it would previously overwrite the `tedge-container-plugin.conf` which could of been edited by the user.