### PR TITLE
fix: remove erroneous compose command failed log message

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -851,10 +851,10 @@ func (c *ContainerClient) ComposeDown(ctx context.Context, w io.Writer, projectN
 				// non critical error
 				slog.Warn("Failed to remove project directory.", "err", removeErr)
 			}
+		} else {
+			errs = append(errs, err)
+			slog.Warn("compose failed.", "err", err)
 		}
-
-		errs = append(errs, err)
-		slog.Warn("compose failed.", "err", err)
 	} else {
 		errs = append(errs, fmt.Errorf("compose project working directory does not exist. dir=%s", workingDir))
 	}


### PR DESCRIPTION
Remove an erroneous warning message which was printed when stopping a container-group. It would result in a warning message "compose failed." always being printed even if there was no error.