### PR TITLE
fix: delete openrc service symlinks before installing package contents

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -105,6 +105,7 @@ nfpms:
       - tedge-container-plugin
 
     scripts:
+      preinstall: ./packaging/scripts/pre-install
       preremove: ./packaging/scripts/pre-remove
       postinstall: ./packaging/scripts/post-install
       postremove: ./packaging/scripts/post-remove

--- a/packaging/scripts/pre-install
+++ b/packaging/scripts/pre-install
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+echo "Running pre-install: $*"
+
+# remove old symlink which will be replaced by a normal file during installation
+if [ -L /etc/init.d/tedge-container-plugin ]; then
+    rm -f /etc/init.d/tedge-container-plugin
+fi
+if [ -L /etc/conf.d/tedge-container-plugin ]; then
+    rm -f /etc/conf.d/tedge-container-plugin
+fi


### PR DESCRIPTION
Fix an issue where the old openrc symlinks for the tedge-container-plugin service were not being replaced by normal files.