### PR TITLE
fix: verify container engine connection on startup and support retries

### DIFF
--- a/cli/container/finalize.go
+++ b/cli/container/finalize.go
@@ -24,7 +24,7 @@ func NewFinalizeCommand(ctx cli.Cli) *cobra.Command {
 			if !pruneImages {
 				return nil
 			}
-			cli, err := container.NewContainerClient()
+			cli, err := container.NewContainerClient(context.TODO())
 			if err != nil {
 				return err
 			}

--- a/cli/container/install.go
+++ b/cli/container/install.go
@@ -75,7 +75,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	// Only enable pulling if the user is providing a file
 	disablePull := c.File != ""
 
-	cli, err := container.NewContainerClient()
+	cli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/container/list.go
+++ b/cli/container/list.go
@@ -22,7 +22,7 @@ func NewListCommand(cliContext cli.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
 			ctx := context.Background()
-			cli, err := container.NewContainerClient()
+			cli, err := container.NewContainerClient(ctx)
 			if err != nil {
 				return err
 			}

--- a/cli/container/remove.go
+++ b/cli/container/remove.go
@@ -35,7 +35,7 @@ Example 1: Remove a container
 			ctx := context.Background()
 			containerName := args[0]
 
-			cli, err := container.NewContainerClient()
+			cli, err := container.NewContainerClient(ctx)
 			if err != nil {
 				return err
 			}

--- a/cli/container_group/finalize.go
+++ b/cli/container_group/finalize.go
@@ -24,7 +24,7 @@ func NewFinalizeCommand(ctx cli.Cli) *cobra.Command {
 			if !pruneImages {
 				return nil
 			}
-			cli, err := container.NewContainerClient()
+			cli, err := container.NewContainerClient(context.TODO())
 			if err != nil {
 				return err
 			}

--- a/cli/container_group/install.go
+++ b/cli/container_group/install.go
@@ -52,7 +52,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	projectName := args[0]
 	stderr := cmd.ErrOrStderr()
 
-	cli, err := container.NewContainerClient()
+	cli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/container_group/list.go
+++ b/cli/container_group/list.go
@@ -42,7 +42,7 @@ func NewListCommand(cliContext cli.Cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			slog.Info("Executing", "cmd", cmd.CalledAs(), "args", args)
 			ctx := context.Background()
-			cli, err := container.NewContainerClient()
+			cli, err := container.NewContainerClient(context.TODO())
 			if err != nil {
 				return err
 			}

--- a/cli/container_group/remove.go
+++ b/cli/container_group/remove.go
@@ -40,7 +40,7 @@ func (c *RemoveCommand) RunE(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	projectName := args[0]
 
-	cli, err := container.NewContainerClient()
+	cli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/engine/docker.go
+++ b/cli/engine/docker.go
@@ -4,6 +4,7 @@ Copyright © 2024 thin-edge.io <info@thin-edge.io>
 package engine
 
 import (
+	"context"
 	"log/slog"
 	"os/exec"
 
@@ -33,7 +34,7 @@ func NewRunCommand(ctx cli.Cli) *cobra.Command {
 
 func (c *DockerCommand) RunE(cmd *cobra.Command, args []string) error {
 	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
-	containerCli, err := container.NewContainerClient()
+	containerCli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/self/check.go
+++ b/cli/self/check.go
@@ -78,7 +78,7 @@ func (c *CheckCommand) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check container self
-	containerCLI, err := container.NewContainerClient()
+	containerCLI, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/self/list.go
+++ b/cli/self/list.go
@@ -36,7 +36,7 @@ func NewListCommand(cliContext cli.Cli) *cobra.Command {
 			}
 
 			ctx := context.Background()
-			containerCli, err := container.NewContainerClient()
+			containerCli, err := container.NewContainerClient(context.TODO())
 			if err != nil {
 				return newNotSupportedErr(err)
 			}

--- a/cli/tools/container_clone.go
+++ b/cli/tools/container_clone.go
@@ -87,7 +87,7 @@ func (c *ContainerCloneCommand) RunE(cmd *cobra.Command, args []string) error {
 		slog.Info("Custom args.", "args", containerCmd)
 	}
 
-	containerCli, err := container.NewContainerClient()
+	containerCli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/tools/container_logs.go
+++ b/cli/tools/container_logs.go
@@ -54,7 +54,7 @@ func NewContainerLogsCommand(ctx cli.Cli) *cobra.Command {
 func (c *ContainerLogsCommand) RunE(cmd *cobra.Command, args []string) error {
 	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
 
-	containerCli, err := container.NewContainerClient()
+	containerCli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/tools/container_remove.go
+++ b/cli/tools/container_remove.go
@@ -46,7 +46,7 @@ func NewContainerRemoveCommand(ctx cli.Cli) *cobra.Command {
 func (c *ContainerRemoveCommand) RunE(cmd *cobra.Command, args []string) error {
 	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
 
-	containerCli, err := container.NewContainerClient()
+	containerCli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/tools/container_restart.go
+++ b/cli/tools/container_restart.go
@@ -40,7 +40,7 @@ func NewContainerRestartCommand(ctx cli.Cli) *cobra.Command {
 func (c *ContainerRestartCommand) RunE(cmd *cobra.Command, args []string) error {
 	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
 
-	containerCli, err := container.NewContainerClient()
+	containerCli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/cli/tools/run_context.go
+++ b/cli/tools/run_context.go
@@ -59,7 +59,7 @@ func NewContainerRunInContextCommand(ctx cli.Cli) *cobra.Command {
 func (c *ContainerRunInContextCommand) RunE(cmd *cobra.Command, args []string) error {
 	slog.Debug("Executing", "cmd", cmd.CalledAs(), "args", args)
 
-	containerCli, err := container.NewContainerClient()
+	containerCli, err := container.NewContainerClient(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -96,7 +96,14 @@ func NewApp(device tedge.Target, config Config) (*App, error) {
 	}
 	tedgeClient := tedge.NewClient(device, *serviceTarget, config.ServiceName, tedgeOpts)
 
-	containerClient, err := container.NewContainerClient()
+	ctx, ctxCancel := context.WithTimeout(context.TODO(), 300*time.Second)
+	defer ctxCancel()
+
+	containerClient, err := container.NewContainerClient(
+		ctx,
+		// Use a time-based timeout instead of limiting number of retries
+		container.WithInfiniteRetries(),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -290,17 +290,53 @@ func findContainerEngineSocket() (socketAddr string) {
 	return socketAddr
 }
 
-func NewContainerClient() (*ContainerClient, error) {
+type Opt func(o *ClientOptions) error
+
+type ClientOptions struct {
+	Attempts      int
+	Host          string
+	RetryInterval time.Duration
+}
+
+func WithAttempts(total int) Opt {
+	return func(o *ClientOptions) error {
+		o.Attempts = total
+		return nil
+	}
+}
+
+func WithInfiniteRetries() Opt {
+	return func(o *ClientOptions) error {
+		o.Attempts = -1
+		return nil
+	}
+}
+
+func WithHost(host string) Opt {
+	return func(o *ClientOptions) error {
+		o.Host = host
+		return nil
+	}
+}
+func WithRetryInterval(v time.Duration) Opt {
+	return func(o *ClientOptions) error {
+		o.RetryInterval = v
+		return nil
+	}
+}
+
+func newContainerClient(options *ClientOptions) (*ContainerClient, error) {
 	// Find container socket
-	addr := findContainerEngineSocket()
-	slog.Info("Using container engine socket.", "value", addr)
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if options.Host == "" {
+		options.Host = findContainerEngineSocket()
+	}
+	if options.Host == "" {
+		return nil, fmt.Errorf("container engine socket was not found")
+	}
+	slog.Info("Using container engine socket.", "value", options.Host)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithHost(options.Host), client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
-	}
-
-	if addr == "" {
-		return nil, fmt.Errorf("container engine socket was not found")
 	}
 
 	// Check if engine is functional
@@ -311,17 +347,63 @@ func NewContainerClient() (*ContainerClient, error) {
 	slog.Info("Found container engine", "name", engineInfo.Name, "version", engineInfo.ServerVersion, "os", engineInfo.OperatingSystem, "osVersion", engineInfo.OSVersion)
 
 	// Only set env variables after the engine has been verified
-	if err := os.Setenv("DOCKER_HOST", addr); err != nil {
+	if err := os.Setenv("DOCKER_HOST", options.Host); err != nil {
 		return nil, err
 	}
 	// Used by podman and podman-remote
-	if err := os.Setenv("CONTAINER_HOST", addr); err != nil {
+	if err := os.Setenv("CONTAINER_HOST", options.Host); err != nil {
 		return nil, err
 	}
 
 	return &ContainerClient{
 		Client: cli,
 	}, nil
+}
+
+func NewContainerClient(ctx context.Context, opts ...Opt) (*ContainerClient, error) {
+	options := &ClientOptions{
+		Attempts:      5,
+		RetryInterval: 5 * time.Second,
+	}
+	for _, opt := range opts {
+		if err := opt(options); err != nil {
+			return nil, err
+		}
+	}
+
+	attempts := 0
+	var client *ContainerClient
+	var err error
+
+	for {
+		client, err = newContainerClient(options)
+		attempts += 1
+
+		if err == nil {
+			return client, nil
+		}
+		slog.Info("Could not create container engine client", "err", err)
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if options.Attempts != -1 && attempts >= options.Attempts {
+			return nil, fmt.Errorf("failed to create container engine client after %d attempts", attempts)
+		}
+
+		t := time.NewTimer(options.RetryInterval)
+		select {
+		case <-ctx.Done():
+			slog.Info("context expired")
+			t.Stop()
+			if ctx.Err() == nil {
+				return nil, fmt.Errorf("failed to create container engine client")
+			}
+			return nil, ctx.Err()
+		case <-t.C:
+			slog.Info("Retrying to create container engine client")
+		}
+	}
 }
 
 type ContainerTelemetryMessage struct {

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -61,8 +61,8 @@ func Test_FilterEnvVariables(t *testing.T) {
 	assert.Equal(t, out[1], "BAR=2")
 }
 
-func Test_PruneIMages(t *testing.T) {
-	client, err := NewContainerClient()
+func Test_PruneImages(t *testing.T) {
+	client, err := NewContainerClient(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Improve the initialization logic of the first connection to the contianer engine by not assuming that the engine is ready at the startup time.

A retry mechanism has been added to retry the container engine connection if the connection fails which allows the container engine socket to start at a later point in time.

Resolves https://github.com/thin-edge/tedge-container-plugin/issues/163