### PR TITLE
fix(clone): copy additional container host settings when cloning a container's config

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1540,6 +1540,26 @@ func CloneHostConfig(ref *container.HostConfig, opts CloneOptions) *container.Ho
 		GroupAdd:        ref.GroupAdd,
 		Runtime:         ref.Runtime,
 		ContainerIDFile: ref.ContainerIDFile,
+		UsernsMode:      ref.UsernsMode,
+		Cgroup:          ref.Cgroup,
+		CgroupnsMode:    ref.CgroupnsMode,
+		UTSMode:         ref.UTSMode,
+		IpcMode:         ref.IpcMode,
+		PidMode:         ref.PidMode,
+		MaskedPaths:     ref.MaskedPaths,
+		Resources: container.Resources{
+			CPUShares:         ref.CPUShares,
+			Memory:            ref.Memory,
+			MemorySwap:        ref.MemorySwap,
+			NanoCPUs:          ref.NanoCPUs,
+			CpusetMems:        ref.CpusetMems,
+			CpusetCpus:        ref.CpusetCpus,
+			CPUPeriod:         ref.CPUPeriod,
+			MemoryReservation: ref.MemoryReservation,
+			OomKillDisable:    ref.OomKillDisable,
+		},
+		ShmSize: ref.ShmSize,
+		Sysctls: ref.Sysctls,
 	}
 
 	if opts.SkipNetwork {


### PR DESCRIPTION
Include additional host settings when cloning a container:

* UsernsMode
* Cgroup
* CgroupnsMode
* UTSMode
* IpcMode
* PidMode
* MaskedPaths
* ShmSize
* Sysctls

And resource related settings
* CPUShares
* Memory
* MemorySwap
* NanoCPUs
* CpusetMems
* CpusetCpus
* CPUPeriod
* MemoryReservation
* OomKillDisable