### PR TITLE
docs: add topic_root and topic_id to the default config

### DIFF
--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -1,6 +1,14 @@
 # Log level. values=debug, info, warn, error
 log_level = "info"
 
+# MQTT root prefix
+# Only change this if you know what you're doing
+# topic_root = "te"
+
+# The device MQTT topic identifier
+# Change if you're running this on a child device, e.g. "device/child01//"
+# topic_id = "device/main//"
+
 # Service name used to show the status of the service
 service_name = "tedge-container-plugin"
 


### PR DESCRIPTION
Add the following config items:

* `topic_root` (default `te`)
* `topic_id` (default `device/main//`)

The topic_id is used when running the tedge-container-plugin on a child device, where you will need to change it to something else, e.g. `device/child01//`.