### PR TITLE
ci: don't publish the debian armv7 package due to a conflict with the armv6 variant

### DIFF
--- a/ci/publish.sh
+++ b/ci/publish.sh
@@ -122,6 +122,10 @@ publish() {
     #  * The component can not be set and is currently fixed to 'main'
     find "$sourcedir" -name "$pattern" -print0 | while read -r -d $'\0' file
     do
+        if [ "$package_type" = "deb" ] && [[ "$file" =~ .+_armv7.deb ]]; then
+            echo "Skipping debian armv7 package as it conflicts with the armv6" >&2
+            continue
+        fi
         cloudsmith upload "$package_type" "${PUBLISH_OWNER}/${PUBLISH_REPO}/${distribution}/${distribution_version}" "$file" \
             --no-wait-for-sync \
             --api-key "${PUBLISH_TOKEN}"


### PR DESCRIPTION
Fix the publishing of the armv6 and armv7 debian packages during the upload to Cloudsmith, as they were overwriting each other due to both packages using the armhf Debian architecture name.

Favour the armv6 version as that can be deployed to both armv6 and armv7 devices.