### PR TITLE
fix: podman rootless userns clone

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -370,20 +370,23 @@ func newContainerClient(options *ClientOptions) (*ContainerClient, error) {
 		return nil, err
 	}
 
+	// Use engine name as an initial hint only; the libpod probe below is authoritative.
+	// Podman returns the machine hostname (not "podman") in Info().Name, so name-based
+	// detection alone is unreliable.
 	engine := detectEngineCapabilities(engineInfo.Name)
 
-	// Attempt to connect to the libpod API when available (podman only).
-	// A failure here is non-fatal; we fall back to the Docker-compat API.
+	// Always probe the libpod API unconditionally. If it responds, this is podman
+	// regardless of what Info().Name says. A failure is non-fatal; we fall back to
+	// the Docker-compat API.
 	var libpod *SocketClient
-	if engine.HasLibPodAPI {
-		lp := NewLibPodHTTPClient(options.Host)
-		if err := lp.Test(context.Background()); err != nil {
-			slog.Warn("libpod API not reachable, falling back to Docker-compat API for all operations", "err", err)
-			engine.HasLibPodAPI = false
-		} else {
-			slog.Info("libpod API available")
-			libpod = lp
-		}
+	lp := NewLibPodHTTPClient(options.Host)
+	if err := lp.Test(context.Background()); err != nil {
+		slog.Debug("libpod API not available, using Docker-compat API", "err", err)
+		// Keep engine type as detected from name (docker/unknown).
+	} else {
+		slog.Info("libpod API available, engine is podman")
+		engine = EngineCapabilities{Type: EnginePodman, HasLibPodAPI: true}
+		libpod = lp
 	}
 
 	return &ContainerClient{
@@ -1310,7 +1313,9 @@ func (c *ContainerClient) CloneContainer(ctx context.Context, containerID string
 
 	// Enrich host config with engine-native data (e.g. recover UsernsMode
 	// "keep-id" that the Docker-compat API normalises to "private" on podman).
-	c.enrichHostConfigForEngine(ctx, containerID, hostConfig)
+	// Use prevContainer.ID (SHA) because the container was already renamed above;
+	// the original name no longer resolves.
+	c.enrichHostConfigForEngine(ctx, prevContainer.ID, hostConfig)
 
 	// Copy network config
 	var networkConfig *network.NetworkingConfig
@@ -1318,7 +1323,7 @@ func (c *ContainerClient) CloneContainer(ctx context.Context, containerID string
 		networkConfig = CloneNetworkConfig(prevContainer.NetworkSettings)
 	}
 
-	slog.Info("Creating new container.", "name", prevContainer.Name, "newImage", opts.Image, "prevImage", prevImage, "config", prevContainer.Config, "host_config", prevContainer.HostConfig)
+	slog.Info("Creating new container.", "name", prevContainer.Name, "newImage", opts.Image, "prevImage", prevImage, "config", prevContainer.Config, "host_config", hostConfig)
 	nextContainer, createErr := c.Client.ContainerCreate(ctx, clonedConfig, hostConfig, networkConfig, nil, containerName)
 
 	if createErr != nil {
@@ -1572,15 +1577,46 @@ func (c *ContainerClient) enrichHostConfigForEngine(ctx context.Context, contain
 //
 // Failures are logged and silently ignored so that caller never aborts due
 // to enrichment – the worst outcome is the same behaviour as before this fix.
+// inferUsernsFromIDMappings detects "keep-id" user namespace mode from a UID
+// mapping table. Podman 4.x incorrectly normalises "keep-id" to "private" in
+// its REST API response. The signature of keep-id is an identity-mapped entry
+// where containerID == hostID (e.g. "999:999:1"). Regular "private" namespaces
+// use the subuid range starting at container UID 0, so no identity entry exists.
+// Returns "keep-id" if detected, or "" otherwise.
+func inferUsernsFromIDMappings(uidMap []string) string {
+	for _, entry := range uidMap {
+		parts := strings.SplitN(entry, ":", 3)
+		if len(parts) == 3 && parts[0] == parts[1] {
+			return "keep-id"
+		}
+	}
+	return ""
+}
+
 func (c *ContainerClient) enrichHostConfigForPodman(ctx context.Context, containerID string, hc *container.HostConfig) {
 	resp, err := c.LibPod.ContainerInspect(ctx, containerID)
 	if err != nil {
 		slog.Warn("libpod inspect failed; UsernsMode may be incorrect in cloned container", "id", containerID, "err", err)
 		return
 	}
+
 	nativeMode := container.UsernsMode(resp.HostConfig.UsernsMode)
+
+	// Podman 4.x normalises "keep-id" → "private" in the REST API response.
+	// Detect the original mode from IDMappings: keep-id leaves an identity
+	// mapping entry (containerID == hostID) that private userns never has.
+	if nativeMode == "private" && resp.HostConfig.IDMappings != nil {
+		if inferred := inferUsernsFromIDMappings(resp.HostConfig.IDMappings.UIDMap); inferred != "" {
+			slog.Info("Inferred UsernsMode keep-id from IDMappings",
+				"id", containerID,
+				"uidMap", resp.HostConfig.IDMappings.UIDMap,
+			)
+			nativeMode = container.UsernsMode(inferred)
+		}
+	}
+
 	if nativeMode != hc.UsernsMode {
-		slog.Info("Correcting UsernsMode from libpod inspect",
+		slog.Info("Correcting UsernsMode for cloned container",
 			"id", containerID,
 			"compat_value", hc.UsernsMode,
 			"libpod_value", nativeMode,
@@ -1673,6 +1709,7 @@ func CloneHostConfig(ref *container.HostConfig, opts CloneOptions) *container.Ho
 			CPUPeriod:         ref.CPUPeriod,
 			MemoryReservation: ref.MemoryReservation,
 			OomKillDisable:    ref.OomKillDisable,
+			PidsLimit:         ref.PidsLimit,
 		},
 		Sysctls: ref.Sysctls,
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -213,6 +213,10 @@ func ConvertName(v []string) string {
 type ContainerClient struct {
 	Client *client.Client
 	Engine EngineCapabilities
+	// LibPod is a client for the podman-native libpod REST API. It is non-nil
+	// only when Engine.HasLibPodAPI is true and the API responded successfully
+	// during initialisation.
+	LibPod *SocketClient
 }
 
 // IsPodman reports whether the connected container engine is podman.
@@ -366,9 +370,26 @@ func newContainerClient(options *ClientOptions) (*ContainerClient, error) {
 		return nil, err
 	}
 
+	engine := detectEngineCapabilities(engineInfo.Name)
+
+	// Attempt to connect to the libpod API when available (podman only).
+	// A failure here is non-fatal; we fall back to the Docker-compat API.
+	var libpod *SocketClient
+	if engine.HasLibPodAPI {
+		lp := NewLibPodHTTPClient(options.Host)
+		if err := lp.Test(context.Background()); err != nil {
+			slog.Warn("libpod API not reachable, falling back to Docker-compat API for all operations", "err", err)
+			engine.HasLibPodAPI = false
+		} else {
+			slog.Info("libpod API available")
+			libpod = lp
+		}
+	}
+
 	return &ContainerClient{
 		Client: cli,
-		Engine: detectEngineCapabilities(engineInfo.Name),
+		Engine: engine,
+		LibPod: libpod,
 	}, nil
 }
 
@@ -1287,6 +1308,10 @@ func (c *ContainerClient) CloneContainer(ctx context.Context, containerID string
 	// Copy host config
 	hostConfig := CloneHostConfig(prevContainer.HostConfig, opts)
 
+	// Enrich host config with engine-native data (e.g. recover UsernsMode
+	// "keep-id" that the Docker-compat API normalises to "private" on podman).
+	c.enrichHostConfigForEngine(ctx, containerID, hostConfig)
+
 	// Copy network config
 	var networkConfig *network.NetworkingConfig
 	if !opts.SkipNetwork {
@@ -1472,6 +1497,10 @@ func (c *ContainerClient) Fork(ctx context.Context, currentContainer container.I
 
 	hostConfig := CloneHostConfig(currentContainer.HostConfig, cloneOptions)
 
+	// Enrich host config with engine-native data (e.g. recover UsernsMode
+	// "keep-id" that the Docker-compat API normalises to "private" on podman).
+	c.enrichHostConfigForEngine(ctx, currentContainer.ID, hostConfig)
+
 	// TODO: Protect against the updater from shutting down due to a machine restart
 	// or is this not required if the restart policy of the container being updated
 	// is left at RestartAlways (as it would restart after a device reboot)
@@ -1523,6 +1552,41 @@ func IsInsideContainer() bool {
 		}
 	}
 	return false
+}
+
+// enrichHostConfigForEngine corrects fields in hc that the Docker-compat API
+// may have normalised.  It dispatches to engine-specific helpers and is a
+// no-op when no enrichment is needed.
+//
+// containerID is the ID or name of the *source* container (the one being
+// cloned or forked), not the newly created one.
+func (c *ContainerClient) enrichHostConfigForEngine(ctx context.Context, containerID string, hc *container.HostConfig) {
+	if c.Engine.HasLibPodAPI && c.LibPod != nil {
+		c.enrichHostConfigForPodman(ctx, containerID, hc)
+	}
+}
+
+// enrichHostConfigForPodman calls the libpod-native inspect endpoint to
+// retrieve the true UsernsMode for the source container and overwrites
+// whatever value the Docker-compat inspect returned.
+//
+// Failures are logged and silently ignored so that caller never aborts due
+// to enrichment – the worst outcome is the same behaviour as before this fix.
+func (c *ContainerClient) enrichHostConfigForPodman(ctx context.Context, containerID string, hc *container.HostConfig) {
+	resp, err := c.LibPod.ContainerInspect(ctx, containerID)
+	if err != nil {
+		slog.Warn("libpod inspect failed; UsernsMode may be incorrect in cloned container", "id", containerID, "err", err)
+		return
+	}
+	nativeMode := container.UsernsMode(resp.HostConfig.UsernsMode)
+	if nativeMode != hc.UsernsMode {
+		slog.Info("Correcting UsernsMode from libpod inspect",
+			"id", containerID,
+			"compat_value", hc.UsernsMode,
+			"libpod_value", nativeMode,
+		)
+		hc.UsernsMode = nativeMode
+	}
 }
 
 func CloneContainerConfig(ref *container.Config, opts CloneOptions) *container.Config {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -212,6 +212,12 @@ func ConvertName(v []string) string {
 
 type ContainerClient struct {
 	Client *client.Client
+	Engine EngineCapabilities
+}
+
+// IsPodman reports whether the connected container engine is podman.
+func (c *ContainerClient) IsPodman() bool {
+	return c.Engine.Type == EnginePodman
 }
 
 func socketExists(p string) bool {
@@ -362,6 +368,7 @@ func newContainerClient(options *ClientOptions) (*ContainerClient, error) {
 
 	return &ContainerClient{
 		Client: cli,
+		Engine: detectEngineCapabilities(engineInfo.Name),
 	}, nil
 }
 

--- a/pkg/container/engine.go
+++ b/pkg/container/engine.go
@@ -1,0 +1,49 @@
+package container
+
+import "strings"
+
+// EngineType identifies the container engine backend.
+// Use the typed constants rather than raw string comparisons throughout the codebase.
+type EngineType string
+
+const (
+	EngineDocker  EngineType = "docker"
+	EnginePodman  EngineType = "podman"
+	EngineUnknown EngineType = "unknown"
+)
+
+// EngineCapabilities describes the features available from the detected engine.
+// Adding a new engine in the future means adding fields here (and a new case in
+// detectEngineCapabilities) without touching any call sites.
+type EngineCapabilities struct {
+	// Type is the engine variant, e.g. EnginePodman or EngineDocker.
+	Type EngineType
+
+	// HasLibPodAPI indicates that the libpod REST API is available at the same
+	// socket. Only true for podman instances.
+	HasLibPodAPI bool
+}
+
+// detectEngineCapabilities maps the engine name string returned by the docker/compat
+// Info() call to an EngineCapabilities value.
+// engineName is compared case-insensitively.
+func detectEngineCapabilities(engineName string) EngineCapabilities {
+	lower := strings.ToLower(engineName)
+	switch {
+	case strings.Contains(lower, "podman"):
+		return EngineCapabilities{
+			Type:         EnginePodman,
+			HasLibPodAPI: true,
+		}
+	case strings.Contains(lower, "docker"):
+		return EngineCapabilities{
+			Type:         EngineDocker,
+			HasLibPodAPI: false,
+		}
+	default:
+		return EngineCapabilities{
+			Type:         EngineUnknown,
+			HasLibPodAPI: false,
+		}
+	}
+}

--- a/pkg/container/engine_test.go
+++ b/pkg/container/engine_test.go
@@ -1,0 +1,182 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------------------------------------------------------------------------
+// detectEngineCapabilities
+// ---------------------------------------------------------------------------
+
+func Test_detectEngineCapabilities_podman(t *testing.T) {
+	caps := detectEngineCapabilities("Podman Engine")
+	assert.Equal(t, EnginePodman, caps.Type)
+	assert.True(t, caps.HasLibPodAPI)
+}
+
+func Test_detectEngineCapabilities_podmanLowerCase(t *testing.T) {
+	caps := detectEngineCapabilities("podman")
+	assert.Equal(t, EnginePodman, caps.Type)
+	assert.True(t, caps.HasLibPodAPI)
+}
+
+func Test_detectEngineCapabilities_docker(t *testing.T) {
+	caps := detectEngineCapabilities("Docker Engine - Community")
+	assert.Equal(t, EngineDocker, caps.Type)
+	assert.False(t, caps.HasLibPodAPI)
+}
+
+func Test_detectEngineCapabilities_unknown(t *testing.T) {
+	caps := detectEngineCapabilities("some-other-runtime")
+	assert.Equal(t, EngineUnknown, caps.Type)
+	assert.False(t, caps.HasLibPodAPI)
+}
+
+func Test_detectEngineCapabilities_empty(t *testing.T) {
+	caps := detectEngineCapabilities("")
+	assert.Equal(t, EngineUnknown, caps.Type)
+	assert.False(t, caps.HasLibPodAPI)
+}
+
+// ---------------------------------------------------------------------------
+// SocketClient.ContainerInspect
+// ---------------------------------------------------------------------------
+
+// newTestLibPodServer starts a minimal httptest.Server that responds to
+// /v5.0.0/libpod/containers/{name}/json with the provided LibPodInspectResponse.
+// It returns both the server and a *SocketClient wired to it.
+func newTestLibPodServer(t *testing.T, resp LibPodInspectResponse) (*httptest.Server, *SocketClient) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/containers/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+
+	sc := &SocketClient{
+		BaseURL: srv.URL + "/v5.0.0/libpod",
+		Client:  srv.Client(),
+	}
+	return srv, sc
+}
+
+func Test_SocketClient_ContainerInspect_keepID(t *testing.T) {
+	want := LibPodInspectResponse{
+		HostConfig: LibPodHostConfig{UsernsMode: "keep-id"},
+	}
+	srv, sc := newTestLibPodServer(t, want)
+	defer srv.Close()
+
+	got, err := sc.ContainerInspect(context.Background(), "mycontainer")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.Equal(t, "keep-id", got.HostConfig.UsernsMode)
+}
+
+func Test_SocketClient_ContainerInspect_private(t *testing.T) {
+	want := LibPodInspectResponse{
+		HostConfig: LibPodHostConfig{UsernsMode: "private"},
+	}
+	srv, sc := newTestLibPodServer(t, want)
+	defer srv.Close()
+
+	got, err := sc.ContainerInspect(context.Background(), "mycontainer")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.Equal(t, "private", got.HostConfig.UsernsMode)
+}
+
+func Test_SocketClient_ContainerInspect_error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	sc := &SocketClient{
+		BaseURL: srv.URL + "/v5.0.0/libpod",
+		Client:  srv.Client(),
+	}
+
+	_, err := sc.ContainerInspect(context.Background(), "noexist")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "404")
+}
+
+// ---------------------------------------------------------------------------
+// enrichHostConfigForPodman
+// ---------------------------------------------------------------------------
+
+func Test_enrichHostConfigForPodman_correctsKeepID(t *testing.T) {
+	libpodResp := LibPodInspectResponse{
+		HostConfig: LibPodHostConfig{UsernsMode: "keep-id"},
+	}
+	srv, sc := newTestLibPodServer(t, libpodResp)
+	defer srv.Close()
+
+	c := &ContainerClient{
+		Engine: EngineCapabilities{Type: EnginePodman, HasLibPodAPI: true},
+		LibPod: sc,
+	}
+
+	hc := &dockercontainer.HostConfig{
+		UsernsMode: dockercontainer.UsernsMode("private"), // normalised value from compat API
+	}
+
+	c.enrichHostConfigForPodman(context.Background(), "mycontainer", hc)
+
+	assert.Equal(t, dockercontainer.UsernsMode("keep-id"), hc.UsernsMode)
+}
+
+func Test_enrichHostConfigForPodman_noChangeWhenAlreadyCorrect(t *testing.T) {
+	libpodResp := LibPodInspectResponse{
+		HostConfig: LibPodHostConfig{UsernsMode: ""},
+	}
+	srv, sc := newTestLibPodServer(t, libpodResp)
+	defer srv.Close()
+
+	c := &ContainerClient{
+		Engine: EngineCapabilities{Type: EnginePodman, HasLibPodAPI: true},
+		LibPod: sc,
+	}
+
+	hc := &dockercontainer.HostConfig{
+		UsernsMode: dockercontainer.UsernsMode(""),
+	}
+
+	c.enrichHostConfigForPodman(context.Background(), "mycontainer", hc)
+
+	assert.Equal(t, dockercontainer.UsernsMode(""), hc.UsernsMode)
+}
+
+func Test_enrichHostConfigForEngine_skipsDockerEngine(t *testing.T) {
+	// Docker uses no libpod enrichment — LibPod pointer stays nil and the
+	// method must be a no-op.
+	c := &ContainerClient{
+		Engine: EngineCapabilities{Type: EngineDocker, HasLibPodAPI: false},
+		LibPod: nil,
+	}
+
+	hc := &dockercontainer.HostConfig{
+		UsernsMode: dockercontainer.UsernsMode("host"),
+	}
+
+	// Must not panic.
+	c.enrichHostConfigForEngine(context.Background(), "anycontainer", hc)
+
+	assert.Equal(t, dockercontainer.UsernsMode("host"), hc.UsernsMode)
+}

--- a/pkg/container/libpod_types.go
+++ b/pkg/container/libpod_types.go
@@ -16,5 +16,15 @@ type LibPodInspectResponse struct {
 type LibPodHostConfig struct {
 	// UsernsMode is the user-namespace mode as stored by podman, e.g. "" (host),
 	// "private", "keep-id", "keep-id:uid=X,gid=Y", "nomap", etc.
-	UsernsMode string `json:"UsernsMode"`
+	// NOTE: podman 4.x normalises "keep-id" to "private" here; use IDMappings
+	// to detect the original mode when this field cannot be trusted.
+	UsernsMode string            `json:"UsernsMode"`
+	IDMappings *LibPodIDMappings `json:"IDMappings,omitempty"`
+}
+
+// LibPodIDMappings holds the UID/GID mapping tables for a container's user
+// namespace. Each entry is in "containerID:hostID:size" format.
+type LibPodIDMappings struct {
+	UIDMap []string `json:"UIDMap"`
+	GIDMap []string `json:"GIDMap"`
 }

--- a/pkg/container/libpod_types.go
+++ b/pkg/container/libpod_types.go
@@ -1,0 +1,20 @@
+package container
+
+// LibPodInspectResponse is a minimal subset of the JSON returned by
+// GET /libpod/containers/{name}/json.  Only the fields needed to recover
+// namespace settings that the Docker-compat API normalises away are captured
+// here.  Add fields as needed; unused fields are silently ignored during
+// JSON deserialisation.
+type LibPodInspectResponse struct {
+	HostConfig LibPodHostConfig `json:"HostConfig"`
+}
+
+// LibPodHostConfig mirrors the HostConfig portion of a libpod container inspect
+// response.  Unlike the Docker-compat API, podman returns the original value for
+// fields like UsernsMode (e.g. "keep-id") rather than a normalised substitute
+// (e.g. "private").
+type LibPodHostConfig struct {
+	// UsernsMode is the user-namespace mode as stored by podman, e.g. "" (host),
+	// "private", "keep-id", "keep-id:uid=X,gid=Y", "nomap", etc.
+	UsernsMode string `json:"UsernsMode"`
+}

--- a/pkg/container/socket_client.go
+++ b/pkg/container/socket_client.go
@@ -120,6 +120,29 @@ type PodmanPullOptions struct {
 	Quiet bool
 }
 
+// ContainerInspect fetches the libpod-native inspect data for the named
+// container.  The returned struct contains fields that the Docker-compat API
+// normalises away (e.g. UsernsMode "keep-id" becomes "private" via compat).
+func (c *SocketClient) ContainerInspect(ctx context.Context, nameOrID string) (*LibPodInspectResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.resolveURL(fmt.Sprintf("containers/%s/json", nameOrID)), nil)
+	if err != nil {
+		return nil, err
+	}
+	r, err := c.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Body.Close() }()
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("libpod inspect: unexpected status %s", r.Status)
+	}
+	var resp LibPodInspectResponse
+	if err := json.NewDecoder(r.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("libpod inspect: decode: %w", err)
+	}
+	return &resp, nil
+}
+
 func (c *SocketClient) PullImages(ctx context.Context, imageRef string, alwaysPull bool, pullOptions PodmanPullOptions) error {
 	options := PodmanAPIPullOptions{
 		Reference: imageRef,

--- a/tests/podman-rootless.robot
+++ b/tests/podman-rootless.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Resource    ./resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
+Suite Setup    Suite Setup
+Test Teardown    Collect Logs
+Test Tags    podman    docker
+
+*** Test Cases ***
+
+Clone a rootless container
+    Execute Command    cmd=rm -f /tmp/info && mkfifo /tmp/info && chown tedge:tedge /tmp/info && chmod 660 /tmp/info && mkdir -p /home/tedge && chown tedge:tedge -R /home/tedge
+    Execute Command    cmd=sudo usermod --add-subuids 100000-165535 tedge && sudo usermod --add-subgids 100000-165535 tedge && sudo usermod -s /bin/bash tedge
+    Execute Command    cmd=sudo -iu tedge systemctl --user start podman.service && loginctl enable-linger tedge
+    Execute Command    cmd=sudo -iu tedge podman run --pids-limit=-1 -d -t -u 1000 --name test01 -v /tmp/info:/tmp/info --userns keep-id alpine sh -c 'while true; do echo hello > /tmp/info; sleep 1; done'
+    Execute Command    cmd=sudo -iu tedge tedge-container tools container-clone --container test01    retries=0
+
+*** Keywords ***
+
+Suite Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
+
+    # Create common network for all containers
+    ${operation}=    Cumulocity.Execute Shell Command    set -a; . /etc/tedge-container-plugin/env; docker network create tedge ||:
+
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir /data


### PR DESCRIPTION
Support cloning podman rootlesss containers which uses the userns property.