### PR TITLE
feat(container-group): track module name upon installation

### DIFF
--- a/cli/container_group/install.go
+++ b/cli/container_group/install.go
@@ -131,8 +131,8 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	versionFile := filepath.Join(workingDir, "version")
-	slog.Info("Writing version to file.", "path", versionFile, "version", c.ModuleVersion)
-	if err := os.WriteFile(versionFile, []byte(c.ModuleVersion), 0644); err != nil {
+	slog.Info("Writing version to file.", "path", versionFile, "version", c.ModuleVersion, "moduleName", projectName)
+	if err := os.WriteFile(versionFile, []byte(c.ModuleVersion+"\n"+projectName), 0644); err != nil {
 		return err
 	}
 

--- a/cli/container_group/list.go
+++ b/cli/container_group/list.go
@@ -33,6 +33,22 @@ func (cp *ComposeProject) GetVersion() string {
 	return scanner.Text()
 }
 
+func (cp *ComposeProject) GetModuleName() string {
+	file, err := os.Open(filepath.Join(cp.Dir, "version"))
+	if err != nil {
+		return cp.Name
+	}
+	defer func() { _ = file.Close() }()
+	scanner := bufio.NewScanner(file)
+	scanner.Scan() // skip version line
+	if scanner.Scan() {
+		if name := scanner.Text(); name != "" {
+			return name
+		}
+	}
+	return cp.Name
+}
+
 // listCmd represents the list command
 func NewListCommand(cliContext cli.Cli) *cobra.Command {
 	return &cobra.Command{
@@ -70,7 +86,7 @@ func NewListCommand(cliContext cli.Cli) *cobra.Command {
 
 			for _, key := range keys {
 				project := projects[key]
-				_, _ = fmt.Fprintf(stdout, "%s\t%s\n", project.Name, project.GetVersion())
+				_, _ = fmt.Fprintf(stdout, "%s\t%s\n", project.GetModuleName(), project.GetVersion())
 			}
 			return nil
 		},

--- a/cli/log_plugins/container_group_plugin/get.go
+++ b/cli/log_plugins/container_group_plugin/get.go
@@ -56,7 +56,17 @@ func (c *ContainerLogsCommand) RunE(cmd *cobra.Command, args []string) error {
 	if !found {
 		return fmt.Errorf("invalid service name. expected name in format of '<project>@<service>'")
 	}
-	services, err := containerCli.LookupProject(context.Background(), projectName, serviceName)
+
+	// The stored service name may use the module name rather than the Docker
+	// compose project name. Resolve it to the actual Docker project label so
+	// the container lookup works regardless.
+	resolvedProjectName, err := containerCli.ResolveComposeProjectName(ctx, projectName)
+	if err != nil {
+		slog.Warn("Could not resolve compose project name, using as-is.", "name", projectName, "err", err)
+		resolvedProjectName = projectName
+	}
+
+	services, err := containerCli.LookupProject(context.Background(), resolvedProjectName, serviceName)
 	if err != nil {
 		return err
 	}

--- a/cli/log_plugins/container_group_plugin/list.go
+++ b/cli/log_plugins/container_group_plugin/list.go
@@ -31,9 +31,15 @@ func NewListCommand(cliContext cli.Cli) *cobra.Command {
 				return err
 			}
 			stdout := cmd.OutOrStdout()
+			useModuleName := cliContext.UseModuleNameForService()
 			for _, item := range containers {
 				if item.ServiceType == container.ContainerGroupType {
-					_, _ = fmt.Fprintf(stdout, "%s\n", item.Name)
+					name := item.Name
+					if !useModuleName && item.Container.ModuleName != "" {
+						item.Container.ModuleName = ""
+						name = item.Container.GetName()
+					}
+					_, _ = fmt.Fprintf(stdout, "%s\n", name)
 				}
 			}
 			return nil

--- a/cli/run/cmd.go
+++ b/cli/run/cmd.go
@@ -45,14 +45,15 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 
 			device := cliContext.GetDeviceTarget()
 			application, err := app.NewApp(device, app.Config{
-				ContainerHost:      cliContext.GetContainerHost(),
-				ServiceName:        cliContext.GetServiceName(),
-				RunOnce:            command.RunOnce,
-				EnableMetrics:      cliContext.MetricsEnabled(),
-				DeleteFromCloud:    cliContext.DeleteFromCloud(),
-				DeleteOrphans:      cliContext.DeleteOrphans(),
-				EnableEngineEvents: cliContext.EngineEventsEnabled(),
-				CrashLoopThreshold: cliContext.GetCrashLoopThreshold(),
+				ContainerHost:           cliContext.GetContainerHost(),
+				ServiceName:             cliContext.GetServiceName(),
+				RunOnce:                 command.RunOnce,
+				EnableMetrics:           cliContext.MetricsEnabled(),
+				DeleteFromCloud:         cliContext.DeleteFromCloud(),
+				DeleteOrphans:           cliContext.DeleteOrphans(),
+				EnableEngineEvents:      cliContext.EngineEventsEnabled(),
+				CrashLoopThreshold:      cliContext.GetCrashLoopThreshold(),
+				UseModuleNameForService: cliContext.UseModuleNameForService(),
 
 				HTTPHost:       cliContext.GetHTTPHost(),
 				HTTPPort:       cliContext.GetHTTPPort(),

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -99,6 +99,17 @@ enabled = true
 # delete orphaned services (related to containers) from the cloud
 orphans = true
 
+[container_group]
+# Control whether the thin-edge service name for container-group services is
+# derived from the module name stored at install time (true) or from
+# the compose project name taken from the Docker container labels (false, default).
+#
+# Set to false when you want the runtime service identity to be decoupled from
+# the software module name. For example, the installed module can be named
+# "myapp-dev" while the compose file has `name: myapp`, so the service shows
+# as "myapp@<service>" regardless of the module version installed.
+use_module_name = false
+
 [registry]
 # Path to the file containing container registry credentials
 credentials_path = "/data/tedge-container-plugin/credentials.toml"

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -104,6 +104,14 @@ type Config struct {
 	// CrashLoopThreshold is the number of daemon-initiated restarts since the
 	// last healthy state required to declare a crash loop.
 	CrashLoopThreshold int
+
+	// UseModuleNameForService controls whether the thin-edge service name for
+	// container-group services is derived from the stored module name (true,
+	// default) or from the compose project name taken from Docker labels
+	// (false). Set to false when you want the runtime service identity to be
+	// decoupled from the software module name, e.g. the module is "myapp-dev"
+	// but the compose project name (and therefore the service name) is "myapp".
+	UseModuleNameForService bool
 }
 
 func NewApp(device tedge.Target, config Config) (*App, error) {
@@ -362,6 +370,7 @@ func (a *App) worker() {
 				if err != nil {
 					slog.Warn("Could not get container list.", "err", err)
 				} else {
+					items = a.applyServiceNamePolicy(items)
 					err = a.updateMetrics(items)
 					if err != nil {
 						slog.Warn("Error updating metrics.", "err", err)
@@ -455,10 +464,17 @@ func getEventAttributes(attr map[string]string, props ...string) []string {
 // for compose services it follows the same "project@service" convention used
 // by Container.GetName() so the event handler and doUpdate() agree on the
 // identity of a service.
-func serviceNameFromEventAttrs(attr map[string]string) string {
+func (a *App) serviceNameFromEventAttrs(attr map[string]string) string {
 	project := attr["com.docker.compose.project"]
 	service := attr["com.docker.compose.service"]
 	if project != "" && service != "" {
+		if a.config.UseModuleNameForService {
+			if workingDir := attr["com.docker.compose.project.working_dir"]; workingDir != "" {
+				if moduleName := container.ReadModuleName(workingDir); moduleName != "" {
+					project = moduleName
+				}
+			}
+		}
 		return project + "@" + service
 	}
 	return attr["name"]
@@ -518,7 +534,7 @@ func (a *App) Monitor(ctx context.Context, filterOptions container.FilterOptions
 					// to the current count so that future crash loops are measured
 					// from this healthy state.
 					if evt.Action == events.ActionHealthStatusHealthy {
-						serviceName := serviceNameFromEventAttrs(evt.Actor.Attributes)
+						serviceName := a.serviceNameFromEventAttrs(evt.Actor.Attributes)
 						if serviceName != "" {
 							if rc, err := a.ContainerClient.GetRestartCount(context.Background(), evt.Actor.ID); err == nil {
 								a.restartBaselineMu.Lock()
@@ -533,7 +549,7 @@ func (a *App) Monitor(ctx context.Context, filterOptions container.FilterOptions
 					// RestartCount before firing the start event, so by the time we
 					// inspect here the count is already current.
 					if evt.Action == events.ActionStart {
-						serviceName := serviceNameFromEventAttrs(evt.Actor.Attributes)
+						serviceName := a.serviceNameFromEventAttrs(evt.Actor.Attributes)
 						if serviceName != "" {
 							if rc, err := a.ContainerClient.GetRestartCount(context.Background(), evt.Actor.ID); err == nil && rc > 0 {
 								a.restartBaselineMu.Lock()
@@ -569,7 +585,7 @@ func (a *App) Monitor(ctx context.Context, filterOptions container.FilterOptions
 					}))
 				case events.ActionDestroy, events.ActionRemove, events.ActionDie:
 					slog.Info("Container removed/destroyed", "container", evt.Actor.ID, "attributes", evt.Actor.Attributes)
-					serviceName := serviceNameFromEventAttrs(evt.Actor.Attributes)
+					serviceName := a.serviceNameFromEventAttrs(evt.Actor.Attributes)
 					if serviceName != "" {
 						switch evt.Action {
 						case events.ActionDestroy, events.ActionRemove:
@@ -587,7 +603,7 @@ func (a *App) Monitor(ctx context.Context, filterOptions container.FilterOptions
 				}
 
 				if a.config.EnableEngineEvents && len(payload) > 0 {
-					serviceName := serviceNameFromEventAttrs(evt.Actor.Attributes)
+					serviceName := a.serviceNameFromEventAttrs(evt.Actor.Attributes)
 					key := serviceName + "/" + string(evt.Action)
 
 					// Determine whether a crash loop is active for this container.
@@ -786,6 +802,23 @@ func (a *App) updateMetrics(items []container.TedgeContainer) error {
 	return errors.Join(jobErrors...)
 }
 
+// applyServiceNamePolicy enforces the UseModuleNameForService setting on a
+// list of containers. When UseModuleNameForService is false the ModuleName
+// stored in the version file is ignored so that the compose project name
+// (from the Docker label) is used as the service name instead.
+func (a *App) applyServiceNamePolicy(items []container.TedgeContainer) []container.TedgeContainer {
+	if a.config.UseModuleNameForService {
+		return items
+	}
+	for i := range items {
+		if items[i].Container.ModuleName != "" {
+			items[i].Container.ModuleName = ""
+			items[i].Name = items[i].Container.GetName()
+		}
+	}
+	return items
+}
+
 func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 	tedgeClient := a.client
 	entities, err := tedgeClient.GetEntities()
@@ -815,6 +848,7 @@ func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 	if err != nil {
 		return err
 	}
+	items = a.applyServiceNamePolicy(items)
 
 	// Register devices
 	slog.Info("Registering containers")

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -60,6 +60,7 @@ func (c *Cli) OnInit() {
 	viper.SetDefault("delete_legacy", true)
 	viper.SetDefault("data_dir", []string{"/data/tedge-container-plugin", "/var/tedge-container-plugin"})
 	viper.SetDefault("registry.credentials_path", "/data/tedge-container-plugin/credentials.toml")
+	viper.SetDefault("container_group.use_module_name", false)
 
 	// Default to the tedge plugins folder
 	if c.ConfigFile == "" {
@@ -174,6 +175,10 @@ func (c *Cli) DeleteOrphans() bool {
 
 func (c *Cli) GetCrashLoopThreshold() int {
 	return viper.GetInt("container.crash_loop_threshold")
+}
+
+func (c *Cli) UseModuleNameForService() bool {
+	return viper.GetBool("container_group.use_module_name")
 }
 
 func (c *Cli) GetHTTPHost() string {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -1,6 +1,7 @@
 package container
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strconv"
@@ -110,6 +112,7 @@ type Container struct {
 	// Only used for container groups
 	ServiceName string `json:"serviceName,omitempty"`
 	ProjectName string `json:"projectName,omitempty"`
+	ModuleName  string `json:"-"`
 
 	// Private values
 	Labels map[string]string `json:"-"`
@@ -145,6 +148,10 @@ func NewContainerFromDockerContainer(item *container.Summary) TedgeContainer {
 		container.ServiceName = v
 	}
 
+	if workingDir, ok := item.Labels["com.docker.compose.project.working_dir"]; ok {
+		container.ModuleName = ReadModuleName(workingDir)
+	}
+
 	container.NetworkIDs = make([]string, 0)
 	if item.NetworkSettings != nil && len(item.NetworkSettings.Networks) > 0 {
 		for _, v := range item.NetworkSettings.Networks {
@@ -169,11 +176,32 @@ func NewContainerFromDockerContainer(item *container.Summary) TedgeContainer {
 	}
 }
 
+// ReadModuleName reads the module name (line 2) from the version file stored
+// in workingDir. Returns an empty string if the file is absent or line 2 is
+// missing/empty, so callers should fall back to the compose project name.
+func ReadModuleName(workingDir string) string {
+	f, err := os.Open(filepath.Join(workingDir, "version"))
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // skip version line
+	if scanner.Scan() {
+		return scanner.Text()
+	}
+	return ""
+}
+
 func (c *Container) GetName() string {
 	if c.ProjectName == "" {
 		return c.Name
 	}
-	return fmt.Sprintf("%s@%s", c.ProjectName, c.ServiceName)
+	project := c.ProjectName
+	if c.ModuleName != "" {
+		project = c.ModuleName
+	}
+	return fmt.Sprintf("%s@%s", project, c.ServiceName)
 }
 
 func ConvertToTedgeStatus(v string) string {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -979,6 +979,43 @@ func (c *ContainerClient) LookupProject(ctx context.Context, projectName string,
 	return projectContainers, err
 }
 
+// ResolveComposeProjectName resolves a name that may be either a Docker
+// compose project name (from the com.docker.compose.project label) or a
+// stored module name (line 2 of the version file in the project working dir).
+// It returns the actual Docker compose project name to use for API calls, or
+// the input name unchanged if no match is found.
+func (c *ContainerClient) ResolveComposeProjectName(ctx context.Context, name string) (string, error) {
+	// First try exact match on the Docker label - cheapest path.
+	direct, err := c.Client.ContainerList(ctx, container.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("label", "com.docker.compose.project="+name)),
+	})
+	if err != nil {
+		return name, err
+	}
+	if len(direct) > 0 {
+		return name, nil
+	}
+
+	// No exact match: scan all compose containers and check their stored module names.
+	all, err := c.Client.ContainerList(ctx, container.ListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.Arg("label", "com.docker.compose.project")),
+	})
+	if err != nil {
+		return name, err
+	}
+	for _, c := range all {
+		workingDir := c.Labels["com.docker.compose.project.working_dir"]
+		if workingDir == "" {
+			continue
+		}
+		if ReadModuleName(workingDir) == name {
+			return c.Labels["com.docker.compose.project"], nil
+		}
+	}
+	return name, nil
+}
+
 func (c *ContainerClient) ComposeDown(ctx context.Context, w io.Writer, projectName string, defaultWorkingDir string) error {
 	// TODO: Read setting from configuration
 	manualCleanup := false

--- a/tests/data/docker-compose.app7-dev.yaml
+++ b/tests/data/docker-compose.app7-dev.yaml
@@ -1,0 +1,14 @@
+name: app7
+services:
+  nginx:
+    image: docker.io/nginx
+    hostname: nginx
+    networks:
+      - tedge
+    ports:
+      - 8080:80
+
+networks:
+  tedge:
+    name: tedge
+    external: true

--- a/tests/operation-container-group.robot
+++ b/tests/operation-container-group.robot
@@ -5,11 +5,11 @@ Library    DeviceLibrary    bootstrap_script=bootstrap.sh
 
 Suite Setup    Suite Setup
 Test Teardown    Collect Logs
-Test Tags    podman    docker
 
 *** Test Cases ***
 
 Install/uninstall container-group package
+    [Tags]    podman    docker
     ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.nginx.yaml
     ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
@@ -41,23 +41,28 @@ Install/uninstall container-group package with custom project name and with usin
     Install/uninstall container-group package with custom project name    module_name=app7-test    service_name=app7-test@nginx    use_module_name=true
 
 Install/uninstall container-group package with non-existent image
+    [Tags]    podman    docker
     ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid-image.yaml
     ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
     Operation Should Be FAILED    ${operation}    timeout=120
 
 Install invalid container-group
+    [Tags]    podman    docker
     ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid.yaml
     ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
     Operation Should Be FAILED    ${operation}    timeout=120
     Device Should Not Have Installed Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
 
 Install container-group with multiple files - app1
+    [Tags]    podman    docker
     Install container-group file    app1    1.0.1    app1    ${CURDIR}/data/apps/app1.tar.gz
 
 Install container-group with multiple files - app2
+    [Tags]    podman    docker
     Install container-group file    app2    1.2.3    app2    ${CURDIR}/data/apps/app2.zip
 
 Install container group that uses host volume mount
+    [Tags]    podman    docker
     [Setup]    Start Service    tedge-container-plugin
     # Install container-group
     Install container-group application    app5    1.0.0    app5    ${CURDIR}/data/apps/app5.tar.gz
@@ -69,6 +74,7 @@ Install container group that uses host volume mount
     Should Contain    ${operation["c8y_Command"]["result"]}    It works
 
 Install container group with a container in a crash loop
+    [Tags]    podman    docker
     [Setup]    Start Service    tedge-container-plugin
 
     ${binary_url}=    Cumulocity.Create Inventory Binary    crash-loop    container-group    file=${CURDIR}/data/docker-compose.crash-loop.yaml

--- a/tests/operation-container-group.robot
+++ b/tests/operation-container-group.robot
@@ -1,0 +1,144 @@
+*** Settings ***
+Resource    ./resources/common.robot
+Library    Cumulocity
+Library    DeviceLibrary    bootstrap_script=bootstrap.sh
+
+Suite Setup    Suite Setup
+Test Teardown    Collect Logs
+Test Tags    podman    docker
+
+*** Test Cases ***
+
+Install/uninstall container-group package
+    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.nginx.yaml
+    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
+    ${operation}=    Cumulocity.Execute Shell Command    wget -O- 127.0.0.1:8080
+    Operation Should Be SUCCESSFUL    ${operation}
+    Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    Welcome to nginx
+    Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    status=up
+
+    # Check if you can request the logs for it
+    Cumulocity.Should Contain Supported Log Types    nginx@nginx::container-group
+    ${operation}=    Cumulocity.Get Log File    nginx@nginx::container-group
+    Operation Should Be SUCCESSFUL    ${operation}
+
+    # Uninstall
+    ${operation}=     Cumulocity.Uninstall Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
+    Operation Should Be SUCCESSFUL    ${operation}
+    Device Should Not Have Installed Software    nginx
+    Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    min_count=0    max_count=0
+
+Install/uninstall container-group package with custom project name and without using module name in services
+    Install/uninstall container-group package with custom project name    module_name=app7-dev    service_name=app7@nginx    use_module_name=false
+
+Install/uninstall container-group package with custom project name and with using module name in services
+    Install/uninstall container-group package with custom project name    module_name=app7-test    service_name=app7-test@nginx    use_module_name=true
+
+Install/uninstall container-group package with non-existent image
+    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid-image.yaml
+    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be FAILED    ${operation}    timeout=120
+
+Install invalid container-group
+    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid.yaml
+    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be FAILED    ${operation}    timeout=120
+    Device Should Not Have Installed Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
+
+Install container-group with multiple files - app1
+    Install container-group file    app1    1.0.1    app1    ${CURDIR}/data/apps/app1.tar.gz
+
+Install container-group with multiple files - app2
+    Install container-group file    app2    1.2.3    app2    ${CURDIR}/data/apps/app2.zip
+
+Install container group that uses host volume mount
+    [Setup]    Start Service    tedge-container-plugin
+    # Install container-group
+    Install container-group application    app5    1.0.0    app5    ${CURDIR}/data/apps/app5.tar.gz
+    Device Should Have Installed Software    {"name": "app5", "version": "1.0.0", "softwareType": "container-group"}
+    Cumulocity.Should Have Services    name=app5@httpd    service_type=container-group    status=up
+
+    ${operation}=    Cumulocity.Execute Shell Command    text=curl -sf http://127.0.0.1:9082
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
+    Should Contain    ${operation["c8y_Command"]["result"]}    It works
+
+Install container group with a container in a crash loop
+    [Setup]    Start Service    tedge-container-plugin
+
+    ${binary_url}=    Cumulocity.Create Inventory Binary    crash-loop    container-group    file=${CURDIR}/data/docker-compose.crash-loop.yaml
+    ${operation}=    Cumulocity.Install Software    {"name": "crash-loop", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+
+    # Install container-group
+    Install container-group application    crash-loop    1.0.0    crash-loop    ${CURDIR}/data/docker-compose.crash-loop.yaml
+    Device Should Have Installed Software    {"name": "crash-loop", "version": "1.0.0", "softwareType": "container-group"}
+    Cumulocity.Should Have Services    name=crash-loop@app    service_type=container-group    status=down
+
+    Cumulocity.Set Managed Object    external_id=${DEVICE_SN}:device:main:service:crash-loop@app
+    Cumulocity.Device Should Have Alarm/s    type=ContainerCrashLoop    expected_text=Container is in a crash loop
+
+    # Uninstall
+    Cumulocity.Set Managed Object    external_id=${DEVICE_SN}
+    ${operation}=     Cumulocity.Uninstall Software    {"name": "crash-loop", "version": "1.0.0", "softwareType": "container-group"}
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Device Should Not Have Installed Software    crash-loop
+    Cumulocity.Should Have Services    name=crash-loop@app    service_type=container-group    min_count=0    max_count=0
+
+*** Keywords ***
+
+Suite Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Cumulocity.External Identity Should Exist    ${DEVICE_SN}
+    Cumulocity.Should Have Services    name=tedge-container-plugin    service_type=service    min_count=1    max_count=1    timeout=30
+
+    # Create common network for all containers
+    ${operation}=    Cumulocity.Execute Shell Command    set -a; . /etc/tedge-container-plugin/env; docker network create tedge ||:
+
+    # Create data directory
+    DeviceLibrary.Execute Command    mkdir /data
+
+Install container-group file
+    [Arguments]    ${package_name}    ${package_version}    ${service_name}    ${file}
+    ${binary_url}=    Cumulocity.Create Inventory Binary    ${package_name}    container-group    file=${file}
+    ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=300
+
+    DeviceLibrary.Directory Should Not Be Empty    /data/tedge-container-plugin/compose/${package_name}
+
+    Device Should Have Installed Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group"}
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/library/busybox wget -O- ${service_name}:80
+    Operation Should Be SUCCESSFUL    ${operation}
+    Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    My Custom Web Application
+    Cumulocity.Should Have Services    name=${package_name}@${service_name}    service_type=container-group    status=up
+
+Install container-group application
+    [Documentation]    Install a container-group and let the user do follow up tests
+    [Arguments]    ${package_name}    ${package_version}    ${service_name}    ${file}
+    ${binary_url}=    Cumulocity.Create Inventory Binary    ${package_name}    container-group    file=${file}
+    ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=300
+
+Install/uninstall container-group package with custom project name
+    [Arguments]    ${module_name}    ${service_name}    ${use_module_name}
+    DeviceLibrary.Execute Command    cmd=sed -i '/^\[container_group\]/,/^\[.*\]/ { s/^use_module_name = .*$/use_module_name = ${use_module_name}/ }' /etc/tedge/plugins/tedge-container-plugin.toml
+    DeviceLibrary.Restart Service    tedge-container-plugin
+
+    ${binary_url}=    Cumulocity.Create Inventory Binary    ${module_name}    container-group    file=${CURDIR}/data/docker-compose.app7-dev.yaml
+    ${operation}=    Cumulocity.Install Software    {"name": "${module_name}", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+    Device Should Have Installed Software    {"name": "${module_name}", "version": "1.0.0", "softwareType": "container-group"}
+    Cumulocity.Should Have Services    name=${service_name}    service_type=container-group    status=up
+
+    # Check if you can request the logs for it
+    Cumulocity.Should Contain Supported Log Types    ${service_name}::container-group
+    ${operation}=    Cumulocity.Get Log File    ${service_name}::container-group
+    Operation Should Be SUCCESSFUL    ${operation}
+
+    # Uninstall
+    ${operation}=     Cumulocity.Uninstall Software    {"name": "${module_name}", "version": "1.0.0", "softwareType": "container-group"}
+    Operation Should Be SUCCESSFUL    ${operation}
+    Device Should Not Have Installed Software    ${module_name}
+    Cumulocity.Should Have Services    name=${service_name}    service_type=container-group    min_count=0    max_count=0

--- a/tests/operation-container-group.robot
+++ b/tests/operation-container-group.robot
@@ -31,9 +31,13 @@ Install/uninstall container-group package
     Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    min_count=0    max_count=0
 
 Install/uninstall container-group package with custom project name and without using module name in services
+    [Tags]    docker
+    # Note: older versions of podman-compose don't support the .name property in the compose, it was added around podman-compose >= 1.3.0
     Install/uninstall container-group package with custom project name    module_name=app7-dev    service_name=app7@nginx    use_module_name=false
 
 Install/uninstall container-group package with custom project name and with using module name in services
+    [Tags]    docker
+    # Note: older versions of podman-compose don't support the .name property in the compose, it was added around podman-compose >= 1.3.0
     Install/uninstall container-group package with custom project name    module_name=app7-test    service_name=app7-test@nginx    use_module_name=true
 
 Install/uninstall container-group package with non-existent image

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -17,44 +17,6 @@ Get Configuration
     ${operation}=    Cumulocity.Get Configuration    typename=tedge-container-plugin
     Operation Should Be SUCCESSFUL    ${operation}
 
-Install/uninstall container-group package
-    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.nginx.yaml
-    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
-    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
-    Device Should Have Installed Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
-    ${operation}=    Cumulocity.Execute Shell Command    wget -O- 127.0.0.1:8080
-    Operation Should Be SUCCESSFUL    ${operation}
-    Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    Welcome to nginx
-    Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    status=up
-
-    # Check if you can request the logs for it
-    Cumulocity.Should Contain Supported Log Types    nginx@nginx::container-group
-    ${operation}=    Cumulocity.Get Log File    nginx@nginx::container-group
-    Operation Should Be SUCCESSFUL    ${operation}
-
-    # Uninstall
-    ${operation}=     Cumulocity.Uninstall Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
-    Operation Should Be SUCCESSFUL    ${operation}
-    Device Should Not Have Installed Software    nginx
-    Cumulocity.Should Have Services    name=nginx@nginx    service_type=container-group    min_count=0    max_count=0
-
-Install/uninstall container-group package with non-existent image
-    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid-image.yaml
-    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
-    Operation Should Be FAILED    ${operation}    timeout=120
-
-Install invalid container-group
-    ${binary_url}=    Cumulocity.Create Inventory Binary    nginx    container-group    file=${CURDIR}/data/docker-compose.invalid.yaml
-    ${operation}=    Cumulocity.Install Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
-    Operation Should Be FAILED    ${operation}    timeout=120
-    Device Should Not Have Installed Software    {"name": "nginx", "version": "1.0.0", "softwareType": "container-group"}
-
-Install container-group with multiple files - app1
-    Install container-group file    app1    1.0.1    app1    ${CURDIR}/data/apps/app1.tar.gz
-
-Install container-group with multiple files - app2
-    Install container-group file    app2    1.2.3    app2    ${CURDIR}/data/apps/app2.zip
-
 Install/uninstall container package
     ${operation}=    Cumulocity.Install Software    {"name": "webserver", "version": "docker.io/library/httpd:2.4", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
@@ -91,7 +53,6 @@ Install/uninstall container package from file
     Operation Should Be SUCCESSFUL    ${operation}
     Device Should Not Have Installed Software    app3
     Cumulocity.Should Have Services    name=app3    service_type=container    min_count=0    max_count=0
-
 
 Manual container creation/deletion
     ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:; sudo tedge-container engine docker run -d --network tedge --name manualapp1 httpd:2.4
@@ -210,39 +171,6 @@ Remove Orphaned Cloud Services eventually if Cumulocity Proxy is Unavailable at 
     Cumulocity.Should Have Services    name=manualapp4    min_count=0    max_count=0    timeout=10
     Cumulocity.Should Have Services    name=app6@httpd    min_count=0    max_count=0    timeout=10
 
-Install container group that uses host volume mount
-    [Setup]    Start Service    tedge-container-plugin
-    # Install container-group
-    Install container-group application    app5    1.0.0    app5    ${CURDIR}/data/apps/app5.tar.gz
-    Device Should Have Installed Software    {"name": "app5", "version": "1.0.0", "softwareType": "container-group"}
-    Cumulocity.Should Have Services    name=app5@httpd    service_type=container-group    status=up
-
-    ${operation}=    Cumulocity.Execute Shell Command    text=curl -sf http://127.0.0.1:9082
-    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
-    Should Contain    ${operation["c8y_Command"]["result"]}    It works
-
-Install container group with a container in a crash loop
-    [Setup]    Start Service    tedge-container-plugin
-
-    ${binary_url}=    Cumulocity.Create Inventory Binary    crash-loop    container-group    file=${CURDIR}/data/docker-compose.crash-loop.yaml
-    ${operation}=    Cumulocity.Install Software    {"name": "crash-loop", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
-    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
-
-    # Install container-group
-    Install container-group application    crash-loop    1.0.0    crash-loop    ${CURDIR}/data/docker-compose.crash-loop.yaml
-    Device Should Have Installed Software    {"name": "crash-loop", "version": "1.0.0", "softwareType": "container-group"}
-    Cumulocity.Should Have Services    name=crash-loop@app    service_type=container-group    status=down
-
-    Cumulocity.Set Managed Object    external_id=${DEVICE_SN}:device:main:service:crash-loop@app
-    Cumulocity.Device Should Have Alarm/s    type=ContainerCrashLoop    expected_text=Container is in a crash loop
-
-    # Uninstall
-    Cumulocity.Set Managed Object    external_id=${DEVICE_SN}
-    ${operation}=     Cumulocity.Uninstall Software    {"name": "crash-loop", "version": "1.0.0", "softwareType": "container-group"}
-    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
-    Cumulocity.Device Should Not Have Installed Software    crash-loop
-    Cumulocity.Should Have Services    name=crash-loop@app    service_type=container-group    min_count=0    max_count=0
-
 *** Keywords ***
 
 Suite Setup
@@ -256,20 +184,6 @@ Suite Setup
 
     # Create data directory
     DeviceLibrary.Execute Command    mkdir /data
-
-Install container-group file
-    [Arguments]    ${package_name}    ${package_version}    ${service_name}    ${file}
-    ${binary_url}=    Cumulocity.Create Inventory Binary    ${package_name}    container-group    file=${file}
-    ${operation}=    Cumulocity.Install Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group", "url": "${binary_url}"}
-    Operation Should Be SUCCESSFUL    ${operation}    timeout=300
-
-    DeviceLibrary.Directory Should Not Be Empty    /data/tedge-container-plugin/compose/${package_name}
-
-    Device Should Have Installed Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group"}
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/library/busybox wget -O- ${service_name}:80
-    Operation Should Be SUCCESSFUL    ${operation}
-    Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    My Custom Web Application
-    Cumulocity.Should Have Services    name=${package_name}@${service_name}    service_type=container-group    status=up
 
 Install container-group application
     [Documentation]    Install a container-group and let the user do follow up tests


### PR DESCRIPTION
Track the cloud module name for installed container-group so that the name is consistent even when a manual project name is defined in the compose yaml file.