### PR TITLE
ci: change pr approval process

### DIFF
--- a/.github/workflows/test-slash-command.yaml
+++ b/.github/workflows/test-slash-command.yaml
@@ -1,0 +1,36 @@
+name: Test (Slash Command)
+
+# Listens for /test comments on pull requests.
+# Because issue_comment always runs in the base-repo context, this workflow
+# has access to repository secrets even for fork PRs.
+#
+# When a maintainer (write/maintain/admin) comments "/test" on a PR:
+#   - peter-evans/slash-command-dispatch validates the permission, adds 👀/🚀
+#     reactions, and fires a repository_dispatch event of type "test-command".
+#   - test.yaml picks up that event and runs the matrix tests against the
+#     PR's head SHA (available in client_payload.pull_request).
+#
+# Requires a repo-scoped PAT stored as the COMMUNITY_ACTIONS_PAT secret so that the action can
+# create repository_dispatch events (GITHUB_TOKEN cannot do this).
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  slash-command-dispatch:
+    name: Dispatch /test command
+    # Only process comments on pull requests
+    if: github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v5
+        with:
+          token: ${{ secrets.COMMUNITY_ACTIONS_PAT }}
+          commands: test
+          permission: write
+          issue-type: pull-request

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,13 +23,45 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test ${{ matrix.job.image }}
+  build:
+    name: Build
     # Skip fork PRs on the pull_request event — they have no secret access.
     # Those PRs are tested via repository_dispatch triggered by test-slash-command.yaml.
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.client_payload.pull_request.head.sha || inputs.ref || github.sha }}
+
+      - uses: taiki-e/install-action@just
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+          cache: false
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: '~> v2'
+          install-only: true
+
+      - name: Build package (for testing)
+        run: just build-local
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-packages
+          path: dist/
+
+  test:
+    name: Test ${{ matrix.job.image }}
+    needs: [build]
     environment:
       name: Test Auto
     permissions:
@@ -50,17 +82,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # repository_dispatch: use the fork PR's head SHA from the slash command payload
           # workflow_dispatch:   use the manually specified ref (or default branch)
           # pull_request / merge_group: use the default (current SHA)
           ref: ${{ github.event.client_payload.pull_request.head.sha || inputs.ref || github.sha }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
         with:
-          install: true
+          name: dist-packages
+          path: dist/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
       - name: create .env file
         run: |
@@ -73,7 +109,7 @@ jobs:
           echo 'REGISTRY1_USERNAME="${{ secrets.REGISTRY1_USERNAME }}"' >> .env
           echo 'REGISTRY1_PASSWORD="${{ secrets.REGISTRY1_PASSWORD }}"' >> .env
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version-file: tests/.py-version
           cache: 'pip'
@@ -81,20 +117,6 @@ jobs:
             tests/requirements.txt
 
       - uses: taiki-e/install-action@just
-
-      #
-      # Build
-      #
-      - uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          cache: false
-      - name: Install dependencies
-        run: |
-          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
-          go install github.com/goreleaser/goreleaser/v2@latest
-      - name: Build package (for testing)
-        run: just build-local
 
       #
       # Test
@@ -108,7 +130,7 @@ jobs:
         run: just test ${{ matrix.job.test_options }}
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: reports-${{ matrix.job.image }}
@@ -125,12 +147,16 @@ jobs:
 
   tests-pass:
     name: Tests Pass
-    needs: [test]
+    needs: [build, test]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check all matrix jobs passed
         run: |
+          if [ "${{ needs.build.result }}" != "success" ]; then
+            echo "Build job failed: ${{ needs.build.result }}"
+            exit 1
+          fi
           if [ "${{ needs.test.result }}" != "success" ]; then
             echo "One or more matrix jobs failed: ${{ needs.test.result }}"
             exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,41 +1,42 @@
 name: Test
 
 on:
-  workflow_dispatch:
-  # Use a manual approval process before PR's are given access to
-  # the secrets which are required to run the integration tests.
-  # The PR code should be manually approved to see if it can be trusted.
-  # When in doubt, do not approve the test run.
-  # Reference: https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci
-  pull_request_target:
+  # Runs automatically for PRs from branches within this repo (maintainers).
+  # Fork PRs do not have access to secrets; maintainers must trigger those
+  # via a /test comment (see test-slash-command.yaml).
+  pull_request:
     branches: [ main ]
+  # Triggered by test-slash-command.yaml via peter-evans/slash-command-dispatch
+  # when a maintainer comments /test on a fork PR.
+  repository_dispatch:
+    types: [test-command]
+  # Allows manually triggering a test run against a specific ref from the UI.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit SHA or branch to test"
+        required: false
+        default: ""
   merge_group:
 
 permissions:
   contents: read
 
 jobs:
-  approve:
-    name: Approve
-    environment:
-      # For security reasons, all pull requests need to be approved first before granting access to secrets
-      # So the environment should be set to have a reviewer/s inspect it before approving it
-      name: ${{ github.event_name == 'pull_request_target' && 'Test Pull Request' || 'Test Auto'  }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for approval
-        run: echo "Approved"
-
   test:
     name: Test ${{ matrix.job.image }}
-    needs: [approve]
+    # Skip fork PRs on the pull_request event — they have no secret access.
+    # Those PRs are tested via repository_dispatch triggered by test-slash-command.yaml.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    environment:
+      name: Test Auto
     permissions:
       # Required to publish system test results to the PR
       issues: write
       pull-requests: write
       contents: read
-    environment:
-      name: Test Auto
     runs-on: ubuntu-latest
     env:
       TEST_IMAGE: ${{ matrix.job.image }}
@@ -51,7 +52,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          # repository_dispatch: use the fork PR's head SHA from the slash command payload
+          # workflow_dispatch:   use the manually specified ref (or default branch)
+          # pull_request / merge_group: use the default (current SHA)
+          ref: ${{ github.event.client_payload.pull_request.head.sha || inputs.ref || github.sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -111,8 +115,23 @@ jobs:
           path: output
 
       - name: Send report to commit
-        if: ${{ always() && github.event_name == 'pull_request_target' }}
+        if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'repository_dispatch') }}
         uses: "joonvena/robotframework-reporter-action@v2.5"
         with:
           report_path: output
           gh_access_token: ${{ secrets.GITHUB_TOKEN }}
+          pull_request_id: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
+          sha: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+
+  tests-pass:
+    name: Tests Pass
+    needs: [test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all matrix jobs passed
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "One or more matrix jobs failed: ${{ needs.test.result }}"
+            exit 1
+          fi


### PR DESCRIPTION
Update PR test approval process by relying on a slash command `/test` to run the system tests for users that don't have write permissions on the repository