### PR TITLE
feat(container-group): automatically add host.containers.internal and host.docker.internal host aliases

### DIFF
--- a/cli/container_group/install.go
+++ b/cli/container_group/install.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/codeclysm/extract/v4"
+	version "github.com/hashicorp/go-version"
 	"github.com/spf13/cobra"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cli"
 	"github.com/thin-edge/tedge-container-plugin/pkg/container"
@@ -123,6 +124,41 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	// Create shared network
 	if err := cli.CreateSharedNetwork(ctx, c.CommandContext.GetSharedContainerNetwork()); err != nil {
 		return err
+	}
+
+	// Normalize host-gateway differences between docker and podman
+	// and their various different versions to make it easier to deploy
+	// compose projects across different container engines and versions
+	if cli.IsPodman() {
+		// Newer podman versions, ≥ 4.7.0 natively adds host.docker.internal and
+		// host.containers.internal, so only added it for older versions
+		podmanNativeDockerInternal := false
+		podmanNativeThreshold, _ := version.NewVersion("4.7")
+		if ver, err := version.NewVersion(cli.Engine.Version); err == nil {
+			podmanNativeDockerInternal = !ver.LessThan(podmanNativeThreshold)
+		}
+
+		if !podmanNativeDockerInternal {
+			// Old Podman: don't support the "host-gateway" reference, so the host.containers.internal
+			// and host.docker.internal aliases need to be manually set to point to an explicit IP address
+			// as defined by the shared network gateway setting
+			if gw := cli.GetNetworkGateway(ctx, c.CommandContext.GetSharedContainerNetwork()); gw != "" {
+				if err := container.EnsureExtraHost(ctx, []string{composeFile}, workingDir, "host.docker.internal", gw); err != nil {
+					slog.Warn("Failed to add host.docker.internal to compose file.", "err", err)
+				}
+			} else {
+				slog.Warn("Could not determine network gateway for host.docker.internal alias; skipping.")
+			}
+		} else {
+			slog.Debug("Podman >= 4.7.0 detected: skipping host.docker.internal injection (added natively).", "version", cli.Engine.Version)
+		}
+	} else {
+		// Docker: inject both cross-engine aliases via the host-gateway special value.
+		for _, hostname := range []string{"host.containers.internal", "host.docker.internal"} {
+			if err := container.EnsureExtraHost(ctx, []string{composeFile}, workingDir, hostname, "host-gateway"); err != nil {
+				slog.Warn("Failed to add extra host to compose file.", "hostname", hostname, "err", err)
+			}
+		}
 	}
 
 	if err := cli.ComposeUp(ctx, stderr, projectName, workingDir, composeUpExtraArgs...); err != nil {

--- a/pkg/container/compose.go
+++ b/pkg/container/compose.go
@@ -1,14 +1,17 @@
 package container
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/hashicorp/go-version"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cmdbuilder"
+	"go.yaml.in/yaml/v3"
 
 	composeCli "github.com/compose-spec/compose-go/v2/cli"
 )
@@ -130,4 +133,149 @@ func ReadImages(ctx context.Context, paths []string, workingDir string) ([]strin
 	}
 
 	return images, nil
+}
+
+// EnsureExtraHost ensures every service in composePaths[0] that does not
+// already define hostname in extra_hosts has "hostname=ipValue" added.
+// Services that already define the hostname (under either the "=" or ":"
+// separator convention) are left unchanged. The file is not written when
+// no patch is required. The yaml node tree is modified in-place so
+// existing formatting and comments are preserved.
+func EnsureExtraHost(ctx context.Context, composePaths []string, _ string, hostname, ipValue string) error {
+	if len(composePaths) == 0 {
+		return nil
+	}
+	composePath := composePaths[0]
+
+	project, err := composeCli.NewProjectOptions(composePaths, composeCli.WithDotEnv)
+	if err != nil {
+		return err
+	}
+	projectT, err := project.LoadProject(ctx)
+	if err != nil {
+		return err
+	}
+
+	needsPatch := make(map[string]bool)
+	for name, service := range projectT.Services {
+		if _, exists := service.ExtraHosts[hostname]; !exists {
+			needsPatch[name] = true
+		}
+	}
+	if len(needsPatch) == 0 {
+		return nil
+	}
+
+	data, err := os.ReadFile(composePath)
+	if err != nil {
+		return err
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return fmt.Errorf("unexpected yaml document structure in %s", composePath)
+	}
+	root := doc.Content[0]
+
+	servicesNode := findMappingValue(root, "services")
+	if servicesNode == nil {
+		return fmt.Errorf("no 'services' key found in %s", composePath)
+	}
+	for i := 0; i+1 < len(servicesNode.Content); i += 2 {
+		if name := servicesNode.Content[i].Value; needsPatch[name] {
+			addExtraHostEntry(servicesNode.Content[i+1], hostname, ipValue)
+		}
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(root); err != nil {
+		return err
+	}
+	if err := enc.Close(); err != nil {
+		return err
+	}
+	services := make([]string, 0, len(needsPatch))
+	for name := range needsPatch {
+		services = append(services, name)
+	}
+	slog.Info("Added extra_hosts entry to compose file.", "file", composePath, "hostname", hostname, "ip", ipValue, "services", services)
+	return os.WriteFile(composePath, buf.Bytes(), 0644)
+}
+
+// findMappingValue returns the value node for key within a YAML MappingNode,
+// or nil if the key is not present.
+func findMappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// addExtraHostEntry appends "hostname=ipValue" to the extra_hosts of a
+// service MappingNode. Both sequence-style and mapping-style extra_hosts are
+// handled. The hostname is matched against both "=" and ":" separator styles
+// to avoid creating duplicates.
+func addExtraHostEntry(serviceNode *yaml.Node, hostname, ipValue string) {
+	// Use ":" separator for maximum compatibility: docker-compose v1 (Python,
+	// <=1.29) only accepts ":" and passes entries verbatim to "docker run
+	// --add-host". The "=" format is compose-spec v2 only. compose-go
+	// accepts both separators when reading, so this works with all versions.
+	entry := hostname + ":" + ipValue
+
+	extraHostsVal := findMappingValue(serviceNode, "extra_hosts")
+	if extraHostsVal == nil {
+		serviceNode.Content = append(serviceNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "extra_hosts"},
+			&yaml.Node{
+				Kind: yaml.SequenceNode,
+				Tag:  "!!seq",
+				Content: []*yaml.Node{
+					{Kind: yaml.ScalarNode, Tag: "!!str", Value: entry},
+				},
+			},
+		)
+		return
+	}
+
+	// A null/empty scalar extra_hosts (e.g. "extra_hosts:" with no value) is
+	// promoted to an empty sequence so we can append to it.
+	if extraHostsVal.Kind == yaml.ScalarNode {
+		extraHostsVal.Kind = yaml.SequenceNode
+		extraHostsVal.Tag = "!!seq"
+		extraHostsVal.Value = ""
+		extraHostsVal.Content = nil
+	}
+
+	switch extraHostsVal.Kind {
+	case yaml.SequenceNode:
+		for _, item := range extraHostsVal.Content {
+			for _, sep := range []string{"=", ":"} {
+				if h, _, ok := strings.Cut(item.Value, sep); ok && h == hostname {
+					return
+				}
+			}
+		}
+		extraHostsVal.Content = append(extraHostsVal.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: entry},
+		)
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(extraHostsVal.Content); i += 2 {
+			if extraHostsVal.Content[i].Value == hostname {
+				return
+			}
+		}
+		extraHostsVal.Content = append(extraHostsVal.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: hostname},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: ipValue},
+		)
+	}
 }

--- a/pkg/container/compose_test.go
+++ b/pkg/container/compose_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/stretchr/testify/assert"
 	"github.com/thin-edge/tedge-container-plugin/pkg/cmdbuilder"
+
+	composeCli "github.com/compose-spec/compose-go/v2/cli"
 )
 
 func Test_Podman(t *testing.T) {
@@ -104,6 +106,118 @@ services:
 		}
 		_, err := ReadImages(context.Background(), []string{invalidComposeFile}, workingDir)
 		assert.Error(t, err)
+	})
+}
+
+func TestEnsureExtraHost(t *testing.T) {
+	ctx := context.Background()
+	const hostname = "host.containers.internal"
+	const ipValue = "host-gateway"
+
+	newComposePath := func(t *testing.T, content string) (dir, path string) {
+		t.Helper()
+		dir, err := os.MkdirTemp("", "compose-extra-host")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(dir) })
+		path = filepath.Join(dir, "docker-compose.yaml")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return dir, path
+	}
+
+	extraHostsFor := func(t *testing.T, path, svcName string) []string {
+		t.Helper()
+		proj, err := composeCli.NewProjectOptions([]string{path}, composeCli.WithDotEnv)
+		if err != nil {
+			t.Fatalf("NewProjectOptions: %v", err)
+		}
+		projectT, err := proj.LoadProject(ctx)
+		if err != nil {
+			t.Fatalf("LoadProject: %v", err)
+		}
+		return projectT.Services[svcName].ExtraHosts[hostname]
+	}
+
+	t.Run("adds entry when no extra_hosts defined", func(t *testing.T) {
+		dir, path := newComposePath(t, `services:
+  app1:
+    image: hello-world
+  app2:
+    image: another-image
+`)
+		assert.NoError(t, EnsureExtraHost(ctx, []string{path}, dir, hostname, ipValue))
+		assert.Contains(t, extraHostsFor(t, path, "app1"), ipValue)
+		assert.Contains(t, extraHostsFor(t, path, "app2"), ipValue)
+	})
+
+	t.Run("no-op when all services already have hostname", func(t *testing.T) {
+		dir, path := newComposePath(t, `services:
+  app1:
+    image: hello-world
+    extra_hosts:
+      - host.containers.internal=host-gateway
+`)
+		assert.NoError(t, EnsureExtraHost(ctx, []string{path}, dir, hostname, ipValue))
+		// Entry must appear exactly once — not duplicated.
+		assert.Len(t, extraHostsFor(t, path, "app1"), 1)
+	})
+
+	t.Run("patches only services missing the hostname", func(t *testing.T) {
+		dir, path := newComposePath(t, `services:
+  app1:
+    image: hello-world
+    extra_hosts:
+      - host.containers.internal=host-gateway
+  app2:
+    image: another-image
+`)
+		assert.NoError(t, EnsureExtraHost(ctx, []string{path}, dir, hostname, ipValue))
+		assert.Len(t, extraHostsFor(t, path, "app1"), 1, "app1 entry should not be duplicated")
+		assert.Contains(t, extraHostsFor(t, path, "app2"), ipValue, "app2 should get the entry")
+	})
+
+	t.Run("appends to existing sequence extra_hosts preserving other entries", func(t *testing.T) {
+		dir, path := newComposePath(t, `services:
+  app1:
+    image: hello-world
+    extra_hosts:
+      - other.host=1.2.3.4
+`)
+		assert.NoError(t, EnsureExtraHost(ctx, []string{path}, dir, hostname, ipValue))
+		assert.Contains(t, extraHostsFor(t, path, "app1"), ipValue)
+
+		// Existing entry must still be present.
+		proj, err := composeCli.NewProjectOptions([]string{path}, composeCli.WithDotEnv)
+		assert.NoError(t, err)
+		projectT, err := proj.LoadProject(ctx)
+		assert.NoError(t, err)
+		assert.Contains(t, projectT.Services["app1"].ExtraHosts["other.host"], "1.2.3.4")
+	})
+
+	t.Run("adds to mapping-style extra_hosts", func(t *testing.T) {
+		dir, path := newComposePath(t, `services:
+  app1:
+    image: hello-world
+    extra_hosts:
+      other.host: "1.2.3.4"
+`)
+		assert.NoError(t, EnsureExtraHost(ctx, []string{path}, dir, hostname, ipValue))
+		assert.Contains(t, extraHostsFor(t, path, "app1"), ipValue)
+	})
+
+	t.Run("recognises colon-separated existing entry as duplicate", func(t *testing.T) {
+		dir, path := newComposePath(t, `services:
+  app1:
+    image: hello-world
+    extra_hosts:
+      - host.containers.internal:host-gateway
+`)
+		assert.NoError(t, EnsureExtraHost(ctx, []string{path}, dir, hostname, ipValue))
+		// compose-go normalises both separator styles to the same key, so exactly one entry.
+		assert.Len(t, extraHostsFor(t, path, "app1"), 1)
 	})
 }
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -409,6 +409,7 @@ func newContainerClient(options *ClientOptions) (*ContainerClient, error) {
 	// Podman returns the machine hostname (not "podman") in Info().Name, so name-based
 	// detection alone is unreliable.
 	engine := detectEngineCapabilities(engineInfo.Name)
+	engine.Version = engineInfo.ServerVersion
 
 	// Always probe the libpod API unconditionally. If it responds, this is podman
 	// regardless of what Info().Name says. A failure is non-fatal; we fall back to
@@ -420,7 +421,7 @@ func newContainerClient(options *ClientOptions) (*ContainerClient, error) {
 		// Keep engine type as detected from name (docker/unknown).
 	} else {
 		slog.Info("libpod API available, engine is podman")
-		engine = EngineCapabilities{Type: EnginePodman, HasLibPodAPI: true}
+		engine = EngineCapabilities{Type: EnginePodman, HasLibPodAPI: true, Version: engineInfo.ServerVersion}
 		libpod = lp
 	}
 
@@ -950,6 +951,21 @@ func (c *ContainerClient) CreateSharedNetwork(ctx context.Context, name string) 
 		slog.Info("Network already exists.", "name", netw.Name, "id", netw.ID)
 	}
 	return nil
+}
+
+// GetNetworkGateway returns the IPv4 gateway address of the named network,
+// or an empty string if it cannot be determined.
+func (c *ContainerClient) GetNetworkGateway(ctx context.Context, name string) string {
+	netw, err := c.Client.NetworkInspect(ctx, name, network.InspectOptions{})
+	if err != nil {
+		return ""
+	}
+	for _, cfg := range netw.IPAM.Config {
+		if cfg.Gateway != "" {
+			return cfg.Gateway
+		}
+	}
+	return ""
 }
 
 func (c *ContainerClient) DockerCommand(args ...string) (string, []string, error) {

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -36,6 +36,63 @@ func Test_ResolveDockerIOImage(t *testing.T) {
 
 }
 
+func Test_NormalizeImageRef(t *testing.T) {
+	testcases := []struct {
+		Input  string
+		Expect string
+	}{
+		// Already fully-qualified — unchanged
+		{Input: "docker.io/library/httpd:2.4", Expect: "docker.io/library/httpd:2.4"},
+		{Input: "docker.io/library/app3:latest", Expect: "docker.io/library/app3:latest"},
+		{Input: "docker.io/myuser/app:1.0", Expect: "docker.io/myuser/app:1.0"},
+		{Input: "ghcr.io/owner/image:tag", Expect: "ghcr.io/owner/image:tag"},
+		// docker.io shorthand expanded to fully-qualified library ref
+		{Input: "docker.io/httpd:2.4", Expect: "docker.io/library/httpd:2.4"},
+		{Input: "docker.io/app3:latest", Expect: "docker.io/library/app3:latest"},
+		// Bare image names reported by older Docker versions are NOT expanded
+		// by NormalizeImageRef; the LabelModuleVersion label is used instead.
+		{Input: "app3:latest", Expect: "app3:latest"},
+		{Input: "httpd:2.4", Expect: "httpd:2.4"},
+	}
+
+	for _, tc := range testcases {
+		got := NormalizeImageRef(tc.Input)
+		if got != tc.Expect {
+			t.Errorf("NormalizeImageRef(%q) = %q, want %q", tc.Input, got, tc.Expect)
+		}
+	}
+}
+
+func Test_ImageRefsEqual(t *testing.T) {
+	equal := []struct{ a, b string }{
+		// Identical
+		{"docker.io/library/app3:latest", "docker.io/library/app3:latest"},
+		// docker.io shorthand vs fully-qualified
+		{"docker.io/app3:latest", "docker.io/library/app3:latest"},
+		// Bare name (Docker v20) vs fully-qualified (what the SM layer sends)
+		{"app3:latest", "docker.io/library/app3:latest"},
+		{"httpd:2.4", "docker.io/library/httpd:2.4"},
+		// User/image form
+		{"myuser/app:1.0", "docker.io/myuser/app:1.0"},
+	}
+	for _, tc := range equal {
+		if !ImageRefsEqual(tc.a, tc.b) {
+			t.Errorf("ImageRefsEqual(%q, %q) should be true", tc.a, tc.b)
+		}
+	}
+
+	notEqual := []struct{ a, b string }{
+		{"ghcr.io/owner/image:tag", "docker.io/library/image:tag"},
+		{"app3:latest", "app3:1.0"},
+		{"docker.io/library/httpd:2.4", "docker.io/library/nginx:2.4"},
+	}
+	for _, tc := range notEqual {
+		if ImageRefsEqual(tc.a, tc.b) {
+			t.Errorf("ImageRefsEqual(%q, %q) should be false", tc.a, tc.b)
+		}
+	}
+}
+
 func Test_FilterLabels(t *testing.T) {
 	in := map[string]string{
 		"foo":                              "bar",

--- a/pkg/container/engine.go
+++ b/pkg/container/engine.go
@@ -22,6 +22,9 @@ type EngineCapabilities struct {
 	// HasLibPodAPI indicates that the libpod REST API is available at the same
 	// socket. Only true for podman instances.
 	HasLibPodAPI bool
+
+	// Version is the server version string reported by the engine (e.g. "4.6.1").
+	Version string
 }
 
 // detectEngineCapabilities maps the engine name string returned by the docker/compat

--- a/tests/data/docker-compose.app8-mqtt-client.yaml
+++ b/tests/data/docker-compose.app8-mqtt-client.yaml
@@ -1,0 +1,9 @@
+services:
+  mqtt-client:
+    image: docker.io/library/eclipse-mosquitto
+    command:
+      - mosquitto_sub
+      - -h
+      - host.containers.internal
+      - -t
+      - "#"

--- a/tests/data/docker-compose.app9-docker-host.yaml
+++ b/tests/data/docker-compose.app9-docker-host.yaml
@@ -1,0 +1,9 @@
+services:
+  mqtt-client:
+    image: docker.io/library/eclipse-mosquitto
+    command:
+      - mosquitto_sub
+      - -h
+      - host.docker.internal
+      - -t
+      - "#"

--- a/tests/operation-container-group.robot
+++ b/tests/operation-container-group.robot
@@ -97,6 +97,14 @@ Install container group with a container in a crash loop
     Cumulocity.Device Should Not Have Installed Software    crash-loop
     Cumulocity.Should Have Services    name=crash-loop@app    service_type=container-group    min_count=0    max_count=0
 
+Podman gateway host is added by default
+    [Tags]    podman    docker
+    Install container-group and access gateway host    app8    service=app8@mqtt-client    file=${CURDIR}/data/docker-compose.app8-mqtt-client.yaml
+
+Docker gateway host is added by default
+    [Tags]    podman    docker
+    Install container-group and access gateway host    app9    service=app9@mqtt-client    file=${CURDIR}/data/docker-compose.app9-docker-host.yaml
+
 *** Keywords ***
 
 Suite Setup
@@ -153,3 +161,12 @@ Install/uninstall container-group package with custom project name
     Operation Should Be SUCCESSFUL    ${operation}
     Device Should Not Have Installed Software    ${module_name}
     Cumulocity.Should Have Services    name=${service_name}    service_type=container-group    min_count=0    max_count=0
+
+Install container-group and access gateway host
+    [Arguments]    ${name}    ${service}    ${file}
+    ${binary_url}=    Cumulocity.Create Inventory Binary    ${name}    container-group    file=${file}
+    ${operation}=    Cumulocity.Install Software    {"name": "${name}", "version": "1.0.0", "softwareType": "container-group", "url": "${binary_url}"}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+
+    Sleep    5s    reason=Give time for the service to fail
+    Cumulocity.Should Have Services    name=${service}    service_type=container-group    status=up


### PR DESCRIPTION
Simplify the deployment of container-group (compose projects) to noramalize the interface across both docker and podman engines, so that the compose file is more portable.

The follow extra hosts are added to the compose projects automatically:

* host.docker.internal
* host.containers.internal

This means that the following docker-compose.yaml across both docker and podman engines

```yaml
services:
  mqtt-client:
    image: docker.io/library/eclipse-mosquitto
    command:
      - mosquitto_sub
      - -h
      - host.containers.internal
      - -t
      - "#"
```