### PR TITLE
fix: honour client options on software management plugins

### DIFF
--- a/cli/container/finalize.go
+++ b/cli/container/finalize.go
@@ -24,7 +24,7 @@ func NewFinalizeCommand(ctx cli.Cli) *cobra.Command {
 			if !pruneImages {
 				return nil
 			}
-			cli, err := container.NewContainerClient(context.TODO())
+			cli, err := container.NewContainerClient(context.TODO(), ctx.GetContainerClientOptions()...)
 			if err != nil {
 				return err
 			}

--- a/cli/container/install.go
+++ b/cli/container/install.go
@@ -75,7 +75,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	// Only enable pulling if the user is providing a file
 	disablePull := c.File != ""
 
-	cli, err := container.NewContainerClient(context.TODO())
+	cli, err := container.NewContainerClient(context.TODO(), c.CommandContext.GetContainerClientOptions()...)
 	if err != nil {
 		return err
 	}

--- a/cli/container_image/install.go
+++ b/cli/container_image/install.go
@@ -66,7 +66,7 @@ func (c *InstallCommand) RunE(cmd *cobra.Command, args []string) error {
 	// Only enable pulling if the user is providing a file
 	disablePull := c.File != ""
 
-	cli, err := container.NewContainerClient(context.TODO())
+	cli, err := container.NewContainerClient(context.TODO(), c.CommandContext.GetContainerClientOptions()...)
 	if err != nil {
 		return err
 	}

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -711,7 +711,7 @@ func (c *ContainerClient) List(ctx context.Context, options FilterOptions) ([]Te
 }
 
 func (c *ContainerClient) MonitorEvents(ctx context.Context) (<-chan events.Message, <-chan error) {
-	return c.Client.Events(context.Background(), events.ListOptions{})
+	return c.Client.Events(ctx, events.ListOptions{})
 }
 
 type ImagePullOptions struct {


### PR DESCRIPTION
The container and container-group software management plugins didn't always respect the configured container engine options when executing the `install` and `finalize` commands which lead to situations that the configured engine host endpoint would be ignored on those subcommands.