### PR TITLE
tests: use mirrored ghcr.io in tests to avoid rate limiting of docker hub

### DIFF
--- a/.github/workflows/mirror-test-images.yml
+++ b/.github/workflows/mirror-test-images.yml
@@ -1,0 +1,36 @@
+name: Mirror test images to GHCR
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # every Monday at 04:00 UTC
+  workflow_dispatch:       # allow manual trigger
+
+jobs:
+  mirror:
+    # Only run on the upstream repo so forks don't need GHCR push access
+    if: github.repository == 'thin-edge/tedge-container-plugin'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write  # required to push to ghcr.io
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y skopeo
+
+      - name: Log in to Docker Hub
+        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" \
+            | skopeo login docker.io -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Mirror images
+        run: bash ci/mirror-test-images.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,8 @@ jobs:
       issues: write
       pull-requests: write
       contents: read
+      # Required to pull private test images from ghcr.io/thin-edge/private-test-images
+      packages: read
     runs-on: ubuntu-latest
     env:
       TEST_IMAGE: ${{ matrix.job.image }}
@@ -113,10 +115,10 @@ jobs:
           echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
-          echo 'PRIVATE_IMAGE="${{ secrets.PRIVATE_IMAGE }}"' >> .env
-          echo 'REGISTRY1_REPO="${{ secrets.REGISTRY1_REPO }}"' >> .env
-          echo 'REGISTRY1_USERNAME="${{ secrets.REGISTRY1_USERNAME }}"' >> .env
-          echo 'REGISTRY1_PASSWORD="${{ secrets.REGISTRY1_PASSWORD }}"' >> .env
+          echo 'PRIVATE_IMAGE="ghcr.io/thin-edge/private-test-images/httpd:2.4"' >> .env
+          echo 'REGISTRY1_REPO="ghcr.io"' >> .env
+          echo 'REGISTRY1_USERNAME="${{ github.actor }}"' >> .env
+          echo 'REGISTRY1_PASSWORD="${{ github.token }}"' >> .env
 
       - uses: actions/setup-python@v6
         with:

--- a/ci/mirror-test-images.sh
+++ b/ci/mirror-test-images.sh
@@ -16,7 +16,13 @@ while read -r ghcr_tag sources_str || [[ -n "${ghcr_tag:-}" ]]; do
     [[ "${ghcr_tag:-}" =~ ^#  ]] && continue
     [[ -z "${ghcr_tag:-}"     ]] && continue
 
-    dest="${GHCR_NAMESPACE}/${ghcr_tag}"
+    # Allow the first column to be a fully-qualified destination (e.g. a
+    # private namespace); otherwise prepend the default GHCR namespace.
+    if [[ "${ghcr_tag}" == ghcr.io/* ]]; then
+        dest="${ghcr_tag}"
+    else
+        dest="${GHCR_NAMESPACE}/${ghcr_tag}"
+    fi
 
     # Try each whitespace-separated source left-to-right; use the first reachable one.
     # skopeo inspect is a single manifest GET — cheap against rate limits.

--- a/ci/mirror-test-images.sh
+++ b/ci/mirror-test-images.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Mirror Docker Hub test images to ghcr.io/thin-edge/test-images to avoid pull rate limits.
+# Usage: ./ci/mirror-test-images.sh
+# Prerequisites:
+#   - skopeo installed (brew install skopeo  /  apt install skopeo)
+#   - logged in to GHCR:
+#       gh auth token | skopeo login ghcr.io -u $(gh api user --jq .login) --password-stdin
+set -euo pipefail
+
+GHCR_NAMESPACE="ghcr.io/thin-edge/test-images"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_LIST="${SCRIPT_DIR}/../tests/test-images.txt"
+
+while read -r ghcr_tag sources_str || [[ -n "${ghcr_tag:-}" ]]; do
+    # skip blank lines and comments
+    [[ "${ghcr_tag:-}" =~ ^#  ]] && continue
+    [[ -z "${ghcr_tag:-}"     ]] && continue
+
+    dest="${GHCR_NAMESPACE}/${ghcr_tag}"
+
+    # Try each whitespace-separated source left-to-right; use the first reachable one.
+    # skopeo inspect is a single manifest GET — cheap against rate limits.
+    source_image=""
+    read -ra source_list <<< "${sources_str}"
+    for candidate in "${source_list[@]}"; do
+        if skopeo inspect --raw "docker://${candidate}" >/dev/null 2>&1; then
+            source_image="${candidate}"
+            break
+        fi
+        echo "Source unavailable, skipping: ${candidate}"
+    done
+
+    if [[ -z "${source_image}" ]]; then
+        echo "ERROR: no reachable source found for ${ghcr_tag} (tried: ${sources_str})" >&2
+        exit 1
+    fi
+
+    # Compare manifest digests — skip if destination is already up to date.
+    # Destination check hits GHCR only; source check is one manifest GET.
+    dest_digest=$(skopeo inspect --raw "docker://${dest}" 2>/dev/null | sha256sum | awk '{print $1}' || echo "none")
+    src_digest=$(skopeo inspect --raw "docker://${source_image}" | sha256sum | awk '{print $1}')
+
+    if [[ "${src_digest}" == "${dest_digest}" ]]; then
+        echo "Already up to date: ${dest} (${src_digest:0:12}…), skipping"
+        continue
+    fi
+
+    echo "Mirroring ${source_image} → ${dest}"
+    # --all preserves the full multi-arch manifest index (no layers pulled locally)
+    # --image-parallel-copies 1 serialises uploads to avoid GHCR burst rate limits
+    # --retry-times 3 handles transient failures automatically
+    skopeo copy \
+        --all \
+        --retry-times 3 \
+        --image-parallel-copies 3 \
+        "docker://${source_image}" \
+        "docker://${dest}"
+done < "${IMAGE_LIST}"

--- a/justfile
+++ b/justfile
@@ -11,8 +11,8 @@ init-dotenv:
   @echo "C8Y_BASEURL=$C8Y_BASEURL" >> .env
   @echo "C8Y_USER=$C8Y_USER" >> .env
   @echo "C8Y_PASSWORD=$C8Y_PASSWORD" >> .env
-  @echo "PRIVATE_IMAGE=docker.io/example/app:latest" >> .env
-  @echo "REGISTRY1_REPO=docker.io" >> .env
+  @echo "PRIVATE_IMAGE=ghcr.io/thin-edge/private-test-images/httpd:2.4" >> .env
+  @echo "REGISTRY1_REPO=ghcr.io" >> .env
   @echo "REGISTRY1_USERNAME=" >> .env
   @echo "REGISTRY1_PASSWORD=" >> .env
 

--- a/tests/container-logs.robot
+++ b/tests/container-logs.robot
@@ -12,7 +12,7 @@ Test Tags    docker    podman
 
 Get Container Logs
     # Run dummy container then exit
-    DeviceLibrary.Execute Command    cmd=tedge-container tools container-remove app10 ||: ; tedge-container engine docker run --name app10 httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; echo hello inside container stderr >&2;'
+    DeviceLibrary.Execute Command    cmd=tedge-container tools container-remove app10 ||: ; tedge-container engine docker run --name app10 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; echo hello inside container stderr >&2;'
 
     # Fetch logs
     ${output}=    DeviceLibrary.Execute Command    sudo tedge-container tools container-logs app10
@@ -21,7 +21,7 @@ Get Container Logs
 
 Get Container Logs with only last N lines
     # Run dummy container then exit
-    DeviceLibrary.Execute Command    cmd=tedge-container engine docker run docker rm app11 >/dev/null 2>&1 ||: ; tedge-container engine docker run --name app11 httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; sleep 1; echo hello inside container stderr >&2;'
+    DeviceLibrary.Execute Command    cmd=tedge-container engine docker run docker rm app11 >/dev/null 2>&1 ||: ; tedge-container engine docker run --name app11 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; sleep 1; echo hello inside container stderr >&2;'
 
     # Fetch logs
     ${output}=    DeviceLibrary.Execute Command    sudo tedge-container tools container-logs app11 -n 1
@@ -34,7 +34,7 @@ Get Container Logs with only last N lines
 
 Get Container Logs By Operation
     # Run dummy container then exit
-    DeviceLibrary.Execute Command    cmd=tedge-container tools container-remove app14 ||: ; tedge-container engine docker run --name app14 httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; echo hello inside container stderr >&2;'
+    DeviceLibrary.Execute Command    cmd=tedge-container tools container-remove app14 ||: ; tedge-container engine docker run --name app14 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine sh -c 'echo hello inside container stdout; echo hello inside container stderr >&2;'
     Cumulocity.Should Contain Supported Log Types    app14::container
     ${operation}=    Cumulocity.Get Log File    app14::container
     Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/container-remove.robot
+++ b/tests/container-remove.robot
@@ -11,7 +11,7 @@ Test Tags    docker    podman
 *** Test Cases ***
 
 Remove Container
-    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app30 ||: ; sudo tedge-container engine docker run -d --network bridge --name app30 httpd:2.4.61-alpine
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app30 ||: ; sudo tedge-container engine docker run -d --network bridge --name app30 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app30    exp_exit_code=0
 
     DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app30

--- a/tests/container-restart.robot
+++ b/tests/container-restart.robot
@@ -34,5 +34,5 @@ Suite Setup
     DeviceLibrary.Execute Command    mkdir /data
 
     # Create a dummy container
-    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app40 ||: ; sudo tedge-container engine docker run -d --network bridge --name app40 httpd:2.4.61-alpine
+    DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-remove app40 ||: ; sudo tedge-container engine docker run -d --network bridge --name app40 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app40    exp_exit_code=0

--- a/tests/data/apps/app1/Dockerfile
+++ b/tests/data/apps/app1/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/nginx
+FROM ghcr.io/thin-edge/test-images/nginx
 COPY static /usr/share/nginx/html

--- a/tests/data/apps/app2/Dockerfile
+++ b/tests/data/apps/app2/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/nginx
+FROM ghcr.io/thin-edge/test-images/nginx
 COPY static /usr/share/nginx/html

--- a/tests/data/apps/app3/Dockerfile
+++ b/tests/data/apps/app3/Dockerfile
@@ -1,2 +1,2 @@
-FROM docker.io/library/alpine:latest
+FROM ghcr.io/thin-edge/test-images/alpine:latest
 ENTRYPOINT [ "/bin/sleep", "infinity" ]

--- a/tests/data/apps/app5/docker-compose.yaml
+++ b/tests/data/apps/app5/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   httpd:
-    image: docker.io/library/httpd:latest
+    image: ghcr.io/thin-edge/test-images/httpd:latest
     volumes:
       - ./htdocs:/var/www/html
     ports:

--- a/tests/data/docker-compose.app7-dev.yaml
+++ b/tests/data/docker-compose.app7-dev.yaml
@@ -1,7 +1,7 @@
 name: app7
 services:
   nginx:
-    image: docker.io/nginx
+    image: ghcr.io/thin-edge/test-images/nginx
     hostname: nginx
     networks:
       - tedge

--- a/tests/data/docker-compose.app8-mqtt-client.yaml
+++ b/tests/data/docker-compose.app8-mqtt-client.yaml
@@ -1,6 +1,6 @@
 services:
   mqtt-client:
-    image: docker.io/library/eclipse-mosquitto
+    image: ghcr.io/thin-edge/test-images/eclipse-mosquitto
     command:
       - mosquitto_sub
       - -h

--- a/tests/data/docker-compose.app9-docker-host.yaml
+++ b/tests/data/docker-compose.app9-docker-host.yaml
@@ -1,6 +1,6 @@
 services:
   mqtt-client:
-    image: docker.io/library/eclipse-mosquitto
+    image: ghcr.io/thin-edge/test-images/eclipse-mosquitto
     command:
       - mosquitto_sub
       - -h

--- a/tests/data/docker-compose.crash-loop.yaml
+++ b/tests/data/docker-compose.crash-loop.yaml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: docker.io/library/debian:13-slim
+    image: ghcr.io/thin-edge/test-images/debian:13-slim
     restart: always
     command:
       - sh

--- a/tests/data/docker-compose.invalid.yaml
+++ b/tests/data/docker-compose.invalid.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   nginx:
-    image: docker.io/nginx
+    image: ghcr.io/thin-edge/test-images/nginx
     hostname: nginx
     networks:
       - tedge-invalid

--- a/tests/data/docker-compose.nginx.yaml
+++ b/tests/data/docker-compose.nginx.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   nginx:
-    image: docker.io/nginx
+    image: ghcr.io/thin-edge/test-images/nginx
     hostname: nginx
     networks:
       - tedge

--- a/tests/operation-container-group.robot
+++ b/tests/operation-container-group.robot
@@ -128,7 +128,7 @@ Install container-group file
     DeviceLibrary.Directory Should Not Be Empty    /data/tedge-container-plugin/compose/${package_name}
 
     Device Should Have Installed Software    {"name": "${package_name}", "version": "${package_version}", "softwareType": "container-group"}
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/library/busybox wget -O- ${service_name}:80
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge ghcr.io/thin-edge/test-images/busybox wget -O- ${service_name}:80
     Operation Should Be SUCCESSFUL    ${operation}
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    My Custom Web Application
     Cumulocity.Should Have Services    name=${package_name}@${service_name}    service_type=container-group    status=up

--- a/tests/operations-clone.robot
+++ b/tests/operations-clone.robot
@@ -11,20 +11,20 @@ Test Tags    docker    podman
 *** Test Cases ***
 
 Check for Update
-    Create Container    app1    docker.io/library/httpd:2.4.61-alpine
+    Create Container    app1    ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine
     DeviceLibrary.Execute Command    cmd=tedge-container engine docker container inspect app1 --format "{{.Id}}"
 
     # No update
-    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image httpd:2.4.61-alpine --check    exp_exit_code=2
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine --check    exp_exit_code=2
 
     # Force update
-    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image httpd:2.4.61-alpine --check --force    exp_exit_code=0
+    DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine --check --force    exp_exit_code=0
 
     # Update is required as local image is not available
     DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app1 --image httpd:2.4.62-alpine --check    exp_exit_code=0
 
 Clone Existing Container
-    Create Container    app2    docker.io/library/httpd:2.4
+    Create Container    app2    ghcr.io/thin-edge/test-images/httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app2 --format "{{.Id}}"
 
     DeviceLibrary.Execute Command    cmd=sudo tedge-container tools container-clone --container app2 --force --label io.thin-edge.last_id=${prev_container_id}
@@ -36,7 +36,7 @@ Clone Existing Container
     Should Be Equal    ${label_prev_id}    ${prev_container_id}
 
 Clone Existing Container by Timeout Whilst Waiting For Exit
-    Create Container    app3    docker.io/library/httpd:2.4
+    Create Container    app3    ghcr.io/thin-edge/test-images/httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app3 --format "{{.Id}}"
 
     DeviceLibrary.Execute Command    sudo tedge-container tools container-clone --container app3 --force --wait-for-exit --stop-timeout 15s    exp_exit_code=!0
@@ -45,7 +45,7 @@ Clone Existing Container by Timeout Whilst Waiting For Exit
     Should Be Equal    ${next_container_id}    ${prev_container_id}
 
 Clone Existing Container but Waiting For Exit
-    Create Container    app4    docker.io/library/httpd:2.4
+    Create Container    app4    ghcr.io/thin-edge/test-images/httpd:2.4
     ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker container inspect app4 --format "{{.Id}}"
 
     ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container tools container-clone --container app4 --force --wait-for-exit --stop-timeout 60s 2>&1
@@ -61,13 +61,13 @@ Clone Existing Container but Waiting For Exit
 
 Ignore Containers With Given Label
     # ignore using label
-    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker run -d --label tedge.ignore=1 --name httpapp1 httpd:2.4.61-alpine
+    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker run -d --label tedge.ignore=1 --name httpapp1 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine
     Sleep    10s
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect httpapp1
     Cumulocity.Should Have Services    service_type=container    name=httpapp1    min_count=0    max_count=0    timeout=10
 
     # don't ignore
-    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker run -d --name httpapp2 httpd:2.4.61-alpine
+    ${prev_container_id}=    DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker run -d --name httpapp2 ghcr.io/thin-edge/test-images/httpd:2.4.61-alpine
     Sleep    10s
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker inspect httpapp2
     Cumulocity.Should Have Services    service_type=container    name=httpapp2    min_count=1    max_count=1    timeout=10

--- a/tests/operations-container-image.robot
+++ b/tests/operations-container-image.robot
@@ -13,7 +13,7 @@ Install/uninstall container-image
     [Documentation]    Docker automatically strips the docker.io/library from the tags so it means
     ...    there isn't a reliable way to distinguish between a local image and a docker.io/library image
     ...    For now, use the shortname when using docker
-    ${IMAGE_NAME}=    Execute Command    cmd=which podman >/dev/null 2>&1 && echo "docker.io/library/httpd" || echo "httpd"    strip=${True}
+    ${IMAGE_NAME}=    Execute Command    cmd=which podman >/dev/null 2>&1 && echo "ghcr.io/thin-edge/test-images/httpd" || echo "ghcr.io/thin-edge/test-images/httpd"    strip=${True}
     ${operation}=    Cumulocity.Install Software    {"name": "${IMAGE_NAME}", "version": "2.4.64", "softwareType": "container-image", "url": ""}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Device Should Have Installed Software    {"name": "${IMAGE_NAME}", "version": "2.4.64", "softwareType": "container-image"}

--- a/tests/operations-private-registries.robot
+++ b/tests/operations-private-registries.robot
@@ -17,6 +17,7 @@ ${REGISTRY1_PASSWORD}       %{REGISTRY1_PASSWORD=}
 
 Install/uninstall container package from private repository - credentials file
     [Tags]    docker    podman
+    Skip If    '${PRIVATE_IMAGE}' == ''    PRIVATE_IMAGE is not set — skipping private registry test
     DeviceLibrary.Execute Command    
     ...    cmd=printf -- '[registry1]\nrepo = "${REGISTRY1_REPO}"\nusername = "${REGISTRY1_USERNAME}"\npassword = "${REGISTRY1_PASSWORD}"\n' > /data/tedge-container-plugin/credentials.toml
 
@@ -26,6 +27,7 @@ Install/uninstall container package from private repository - credentials file
 
 Install/uninstall container package from private repository - credentials script
     [Tags]    docker    podman
+    Skip If    '${PRIVATE_IMAGE}' == ''    PRIVATE_IMAGE is not set — skipping private registry test
     Transfer To Device    ${CURDIR}/data/registry-credentials    /usr/bin/
     DeviceLibrary.Execute Command    cmd=sed -i 's|@@USERNAME@@|${REGISTRY1_USERNAME}|g' /usr/bin/registry-credentials
     DeviceLibrary.Execute Command    cmd=sed -i 's|@@PASSWORD@@|${REGISTRY1_PASSWORD}|g' /usr/bin/registry-credentials
@@ -36,6 +38,7 @@ Install/uninstall container package from private repository - credentials script
 
 Install/uninstall container package from private repository - credentials script with cache
     [Tags]    docker    podman
+    Skip If    '${PRIVATE_IMAGE}' == ''    PRIVATE_IMAGE is not set — skipping private registry test
     Transfer To Device    ${CURDIR}/data/registry-credentials-with-cache    /usr/bin/registry-credentials
     DeviceLibrary.Execute Command    cmd=sed -i 's|@@USERNAME@@|${REGISTRY1_USERNAME}|g' /usr/bin/registry-credentials
     DeviceLibrary.Execute Command    cmd=sed -i 's|@@PASSWORD@@|${REGISTRY1_PASSWORD}|g' /usr/bin/registry-credentials
@@ -47,6 +50,7 @@ Install/uninstall container package from private repository - credentials script
 Install/uninstall container package from private repository - engine credentials (rootful)
     [Documentation]    login to registry from host
     [Tags]    podman    rootful
+    Skip If    '${PRIVATE_IMAGE}' == ''    PRIVATE_IMAGE is not set — skipping private registry test
     DeviceLibrary.Execute Command    tedge-container engine docker login ${REGISTRY1_REPO} -u '${REGISTRY1_USERNAME}' --password '${REGISTRY1_PASSWORD}'
     ${operation}=    Cumulocity.Install Software    {"name": "testapp3", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
@@ -55,6 +59,7 @@ Install/uninstall container package from private repository - engine credentials
 Install/uninstall container package from private repository - engine credentials (rootless)
     [Documentation]    login to registry from host
     [Tags]    podman    rootless
+    Skip If    '${PRIVATE_IMAGE}' == ''    PRIVATE_IMAGE is not set — skipping private registry test
     DeviceLibrary.Execute Command    sudo -u tedge tedge-container engine docker login ${REGISTRY1_REPO} -u '${REGISTRY1_USERNAME}' --password '${REGISTRY1_PASSWORD}'
     ${operation}=    Cumulocity.Install Software    {"name": "testapp3", "version": "${PRIVATE_IMAGE}", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
@@ -63,6 +68,7 @@ Install/uninstall container package from private repository - engine credentials
 Install/uninstall container package from private repository - docker from docker (rootful)
     [Documentation]    login inside a container with the auth file mounted from the host
     [Tags]    podman    rootful
+    Skip If    '${PRIVATE_IMAGE}' == ''    PRIVATE_IMAGE is not set — skipping private registry test
 
     # Start a container
     DeviceLibrary.Execute Command    mkdir -p /run/containers/0/

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -18,10 +18,10 @@ Get Configuration
     Operation Should Be SUCCESSFUL    ${operation}
 
 Install/uninstall container package
-    ${operation}=    Cumulocity.Install Software    {"name": "webserver", "version": "docker.io/library/httpd:2.4", "softwareType": "container"}
+    ${operation}=    Cumulocity.Install Software    {"name": "webserver", "version": "ghcr.io/thin-edge/test-images/httpd:2.4", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
-    Device Should Have Installed Software    {"name": "webserver", "version": "docker.io/library/httpd:2.4", "softwareType": "container"}
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/library/busybox wget -O- webserver:80;
+    Device Should Have Installed Software    {"name": "webserver", "version": "ghcr.io/thin-edge/test-images/httpd:2.4", "softwareType": "container"}
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge ghcr.io/thin-edge/test-images/busybox wget -O- webserver:80;
     Operation Should Be SUCCESSFUL    ${operation}
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    It works!
     Cumulocity.Should Have Services    name=webserver    service_type=container    status=up
@@ -32,7 +32,7 @@ Install/uninstall container package
     Operation Should Be SUCCESSFUL    ${operation}
 
     # Uninstall
-    ${operation}=     Cumulocity.Uninstall Software    {"name": "webserver", "version": "docker.io/library/httpd:2.4", "softwareType": "container"}
+    ${operation}=     Cumulocity.Uninstall Software    {"name": "webserver", "version": "ghcr.io/thin-edge/test-images/httpd:2.4", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}
     Device Should Not Have Installed Software    webserver
     Cumulocity.Should Have Services    name=webserver    service_type=container    min_count=0    max_count=0
@@ -55,10 +55,10 @@ Install/uninstall container package from file
     Cumulocity.Should Have Services    name=app3    service_type=container    min_count=0    max_count=0
 
 Manual container creation/deletion
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:; sudo tedge-container engine docker rm -f manualapp1 ||: ; sudo tedge-container engine docker run -d --network tedge --name manualapp1 httpd:2.4
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker network create tedge ||:; sudo tedge-container engine docker rm -f manualapp1 ||: ; sudo tedge-container engine docker run -d --network tedge --name manualapp1 ghcr.io/thin-edge/test-images/httpd:2.4
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
 
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge docker.io/library/busybox wget -O- manualapp1:80;
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run --rm -t --network tedge ghcr.io/thin-edge/test-images/busybox wget -O- manualapp1:80;
     Operation Should Be SUCCESSFUL    ${operation}
 
     Should Contain    ${operation.to_json()["c8y_Command"]["result"]}    It works!
@@ -86,7 +86,7 @@ Manual container creation/deletion
     Cumulocity.Should Not Contain Supported Log Types    manualapp1::container
 
 Manual container creation/deletion with error on run
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run -d --name manualapp2 httpd:2.4 --invalid-arg || exit 0
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run -d --name manualapp2 ghcr.io/thin-edge/test-images/httpd:2.4 --invalid-arg || exit 0
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Cumulocity.Should Have Services    name=manualapp2    service_type=container    status=down
 
@@ -97,7 +97,7 @@ Manual container creation/deletion with error on run
 
 
 Manual container created and then killed
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker rm -f manualapp3 ||: ; sudo tedge-container engine docker run -d --name manualapp3 busybox sh -c 'exec sleep infinity'
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker rm -f manualapp3 ||: ; sudo tedge-container engine docker run -d --name manualapp3 ghcr.io/thin-edge/test-images/busybox sh -c 'exec sleep infinity'
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Cumulocity.Should Have Services    name=manualapp3    service_type=container    status=up
 
@@ -114,7 +114,7 @@ Manual container created and then killed
 Remove Orphaned Cloud Services
     [Documentation]    Orphaned cloud services can occur if entities are deregistered manually when the tedge-container-plugin
     ...    service is not running.
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run -d --name manualapp4 busybox sh -c 'exec sleep infinity'
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run -d --name manualapp4 ghcr.io/thin-edge/test-images/busybox sh -c 'exec sleep infinity'
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Cumulocity.Should Have Services    name=manualapp4    service_type=container    status=up
 
@@ -146,7 +146,7 @@ Remove Orphaned Cloud Services eventually if Cumulocity Proxy is Unavailable at 
     ...    See https://github.com/thin-edge/tedge-container-plugin/issues/181
 
     # create a local container manually
-    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run -d --name manualapp4 busybox sh -c 'exec sleep infinity'
+    ${operation}=    Cumulocity.Execute Shell Command    sudo tedge-container engine docker run -d --name manualapp4 ghcr.io/thin-edge/test-images/busybox sh -c 'exec sleep infinity'
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
     Cumulocity.Should Have Services    name=manualapp4    service_type=container    status=up
 

--- a/tests/podman-rootless.robot
+++ b/tests/podman-rootless.robot
@@ -13,7 +13,7 @@ Clone a rootless container
     Execute Command    cmd=rm -f /tmp/info && mkfifo /tmp/info && chown tedge:tedge /tmp/info && chmod 660 /tmp/info && mkdir -p /home/tedge && chown tedge:tedge -R /home/tedge
     Execute Command    cmd=sudo usermod --add-subuids 100000-165535 tedge && sudo usermod --add-subgids 100000-165535 tedge && sudo usermod -s /bin/bash tedge
     Execute Command    cmd=loginctl enable-linger tedge && sudo -iu tedge systemctl --user start podman.service
-    Execute Command    cmd=sudo -iu tedge podman rm -f test01; sudo -iu tedge podman run --pids-limit=-1 -d -t -u 1000 --name test01 -v /tmp/info:/tmp/info --userns keep-id alpine sh -c 'while true; do echo hello > /tmp/info; sleep 1; done'
+    Execute Command    cmd=sudo -iu tedge podman rm -f test01; sudo -iu tedge podman run --pids-limit=-1 -d -t -u 1000 --name test01 -v /tmp/info:/tmp/info --userns keep-id ghcr.io/thin-edge/test-images/alpine sh -c 'while true; do echo hello > /tmp/info; sleep 1; done'
     Execute Command    cmd=sudo -iu tedge tedge-container tools container-clone --container test01    retries=0
 
 *** Keywords ***

--- a/tests/telemetry-main.robot
+++ b/tests/telemetry-main.robot
@@ -36,12 +36,12 @@ Test Setup
     Cumulocity.External Identity Should Exist    ${DEVICE_SN}
 
 Install Example Container
-    ${operation}=    Cumulocity.Install Software    {"name": "customapp1", "version": "httpd:2.4", "softwareType": "container"}
+    ${operation}=    Cumulocity.Install Software    {"name": "customapp1", "version": "ghcr.io/thin-edge/test-images/httpd:2.4", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
 
 Uninstall Example Container
     Cumulocity.Set Managed Object    ${DEVICE_SN}
-    ${operation}=    Cumulocity.Uninstall Software    {"name": "customapp1", "version": "httpd:2.4", "softwareType": "container"}
+    ${operation}=    Cumulocity.Uninstall Software    {"name": "customapp1", "version": "ghcr.io/thin-edge/test-images/httpd:2.4", "softwareType": "container"}
     Operation Should Be SUCCESSFUL    ${operation}    timeout=60
 
 Get Service External ID

--- a/tests/test-images.txt
+++ b/tests/test-images.txt
@@ -16,3 +16,7 @@ nginx:latest                public.ecr.aws/nginx/nginx:latest                   
 eclipse-mosquitto:latest    public.ecr.aws/docker/library/eclipse-mosquitto:latest    docker.io/library/eclipse-mosquitto:latest
 debian:13-slim              public.ecr.aws/docker/library/debian:13-slim               docker.io/library/debian:13-slim
 
+# Private image used to test private-registry authentication (operations-private-registries.robot).
+# Fully-qualified destination overrides the default ghcr.io/thin-edge/test-images namespace.
+ghcr.io/thin-edge/private-test-images/httpd:2.4    public.ecr.aws/docker/library/httpd:2.4    docker.io/library/httpd:2.4
+

--- a/tests/test-images.txt
+++ b/tests/test-images.txt
@@ -1,0 +1,18 @@
+# Images mirrored to ghcr.io/thin-edge/test-images to avoid Docker Hub pull rate limits.
+# Format: <ghcr-tag>  <source1>  [<source2>  ...]
+# Whitespace-separated (spaces or tabs). Sources are tried left-to-right; the first
+# reachable one is used. Add extra sources by appending columns.
+# See ci/mirror-test-images.sh and .github/workflows/mirror-test-images.yml.
+
+# ghcr tag                  preferred source (ECR, no rate limit)                    fallback source (Docker Hub)
+httpd:2.4                   public.ecr.aws/docker/library/httpd:2.4                   docker.io/library/httpd:2.4
+httpd:2.4.61-alpine         public.ecr.aws/docker/library/httpd:2.4.61-alpine         docker.io/library/httpd:2.4.61-alpine
+httpd:2.4.64                public.ecr.aws/docker/library/httpd:2.4.64                docker.io/library/httpd:2.4.64
+httpd:2.4.65                public.ecr.aws/docker/library/httpd:2.4.65                docker.io/library/httpd:2.4.65
+httpd:latest                public.ecr.aws/docker/library/httpd:latest                docker.io/library/httpd:latest
+busybox:latest              public.ecr.aws/docker/library/busybox:latest              docker.io/library/busybox:latest
+alpine:latest               public.ecr.aws/docker/library/alpine:latest               docker.io/library/alpine:latest
+nginx:latest                public.ecr.aws/nginx/nginx:latest                         docker.io/nginx:latest
+eclipse-mosquitto:latest    public.ecr.aws/docker/library/eclipse-mosquitto:latest    docker.io/library/eclipse-mosquitto:latest
+debian:13-slim              public.ecr.aws/docker/library/debian:13-slim               docker.io/library/debian:13-slim
+


### PR DESCRIPTION
Some system tests were failing due to hitting the docker hub rate limit. The new setup uses copies of the container images hosted in ghcr.io which has higher limits that should be more reliable for testing.

In the future, we could also extend the test setup to also do a `docker login` using the runner's GITHUB_TOKEN to increase the limits even further, but we're avoiding that for now if it is not strictly required.