### PR TITLE
ci: add workflow to periodically mirror test images to GHCR

### DIFF
--- a/.github/workflows/mirror-test-images.yml
+++ b/.github/workflows/mirror-test-images.yml
@@ -1,0 +1,36 @@
+name: Mirror test images to GHCR
+
+on:
+  schedule:
+    - cron: '0 4 * * 1'  # every Monday at 04:00 UTC
+  workflow_dispatch:       # allow manual trigger
+
+jobs:
+  mirror:
+    # Only run on the upstream repo so forks don't need GHCR push access
+    if: github.repository == 'thin-edge/tedge-container-plugin'
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write  # required to push to ghcr.io
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install skopeo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y skopeo
+
+      - name: Log in to Docker Hub
+        if: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" \
+            | skopeo login docker.io -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Log in to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | skopeo login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Mirror images
+        run: bash ci/mirror-test-images.sh

--- a/ci/mirror-test-images.sh
+++ b/ci/mirror-test-images.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Mirror Docker Hub test images to ghcr.io/thin-edge/test-images to avoid pull rate limits.
+# Usage: ./ci/mirror-test-images.sh
+# Prerequisites:
+#   - skopeo installed (brew install skopeo  /  apt install skopeo)
+#   - logged in to GHCR:
+#       gh auth token | skopeo login ghcr.io -u $(gh api user --jq .login) --password-stdin
+set -euo pipefail
+
+GHCR_NAMESPACE="ghcr.io/thin-edge/test-images"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_LIST="${SCRIPT_DIR}/../tests/test-images.txt"
+
+while read -r ghcr_tag sources_str || [[ -n "${ghcr_tag:-}" ]]; do
+    # skip blank lines and comments
+    [[ "${ghcr_tag:-}" =~ ^#  ]] && continue
+    [[ -z "${ghcr_tag:-}"     ]] && continue
+
+    # Allow the first column to be a fully-qualified destination (e.g. a
+    # private namespace); otherwise prepend the default GHCR namespace.
+    if [[ "${ghcr_tag}" == ghcr.io/* ]]; then
+        dest="${ghcr_tag}"
+    else
+        dest="${GHCR_NAMESPACE}/${ghcr_tag}"
+    fi
+
+    # Try each whitespace-separated source left-to-right; use the first reachable one.
+    # skopeo inspect is a single manifest GET — cheap against rate limits.
+    source_image=""
+    read -ra source_list <<< "${sources_str}"
+    for candidate in "${source_list[@]}"; do
+        if skopeo inspect --raw "docker://${candidate}" >/dev/null 2>&1; then
+            source_image="${candidate}"
+            break
+        fi
+        echo "Source unavailable, skipping: ${candidate}"
+    done
+
+    if [[ -z "${source_image}" ]]; then
+        echo "ERROR: no reachable source found for ${ghcr_tag} (tried: ${sources_str})" >&2
+        exit 1
+    fi
+
+    # Compare manifest digests — skip if destination is already up to date.
+    # Destination check hits GHCR only; source check is one manifest GET.
+    dest_digest=$(skopeo inspect --raw "docker://${dest}" 2>/dev/null | sha256sum | awk '{print $1}' || echo "none")
+    src_digest=$(skopeo inspect --raw "docker://${source_image}" | sha256sum | awk '{print $1}')
+
+    if [[ "${src_digest}" == "${dest_digest}" ]]; then
+        echo "Already up to date: ${dest} (${src_digest:0:12}…), skipping"
+        continue
+    fi
+
+    echo "Mirroring ${source_image} → ${dest}"
+    # --all preserves the full multi-arch manifest index (no layers pulled locally)
+    # --image-parallel-copies 1 serialises uploads to avoid GHCR burst rate limits
+    # --retry-times 3 handles transient failures automatically
+    skopeo copy \
+        --all \
+        --retry-times 3 \
+        --image-parallel-copies 3 \
+        "docker://${source_image}" \
+        "docker://${dest}"
+done < "${IMAGE_LIST}"

--- a/justfile
+++ b/justfile
@@ -11,8 +11,8 @@ init-dotenv:
   @echo "C8Y_BASEURL=$C8Y_BASEURL" >> .env
   @echo "C8Y_USER=$C8Y_USER" >> .env
   @echo "C8Y_PASSWORD=$C8Y_PASSWORD" >> .env
-  @echo "PRIVATE_IMAGE=docker.io/example/app:latest" >> .env
-  @echo "REGISTRY1_REPO=docker.io" >> .env
+  @echo "PRIVATE_IMAGE=ghcr.io/thin-edge/private-test-images/httpd:2.4" >> .env
+  @echo "REGISTRY1_REPO=ghcr.io" >> .env
   @echo "REGISTRY1_USERNAME=" >> .env
   @echo "REGISTRY1_PASSWORD=" >> .env
 

--- a/tests/test-images.txt
+++ b/tests/test-images.txt
@@ -1,0 +1,21 @@
+# Images mirrored to ghcr.io/thin-edge/test-images to avoid Docker Hub pull rate limits.
+# Format: <ghcr-tag>  <source1>  [<source2>  ...]
+# Whitespace-separated (spaces or tabs). Sources are tried left-to-right; the first
+# reachable one is used. Add extra sources by appending columns.
+# See ci/mirror-test-images.sh and .github/workflows/mirror-test-images.yml.
+
+# ghcr tag                  preferred source (ECR, no rate limit)                    fallback source (Docker Hub)
+httpd:2.4                   public.ecr.aws/docker/library/httpd:2.4                   docker.io/library/httpd:2.4
+httpd:2.4.61-alpine         public.ecr.aws/docker/library/httpd:2.4.61-alpine         docker.io/library/httpd:2.4.61-alpine
+httpd:2.4.64                public.ecr.aws/docker/library/httpd:2.4.64                docker.io/library/httpd:2.4.64
+httpd:2.4.65                public.ecr.aws/docker/library/httpd:2.4.65                docker.io/library/httpd:2.4.65
+httpd:latest                public.ecr.aws/docker/library/httpd:latest                docker.io/library/httpd:latest
+busybox:latest              public.ecr.aws/docker/library/busybox:latest              docker.io/library/busybox:latest
+alpine:latest               public.ecr.aws/docker/library/alpine:latest               docker.io/library/alpine:latest
+nginx:latest                public.ecr.aws/nginx/nginx:latest                         docker.io/nginx:latest
+eclipse-mosquitto:latest    public.ecr.aws/docker/library/eclipse-mosquitto:latest    docker.io/library/eclipse-mosquitto:latest
+debian:13-slim              public.ecr.aws/docker/library/debian:13-slim               docker.io/library/debian:13-slim
+
+# Private image used to test private-registry authentication (operations-private-registries.robot).
+# Fully-qualified destination overrides the default ghcr.io/thin-edge/test-images namespace.
+ghcr.io/thin-edge/private-test-images/httpd:2.4    public.ecr.aws/docker/library/httpd:2.4    docker.io/library/httpd:2.4


### PR DESCRIPTION
Adds a weekly GitHub Actions workflow (`mirror-test-images.yml`) that mirrors Docker Hub test images to `ghcr.io/thin-edge/test-images/` to avoid pull rate limits during system tests.

Also mirrors a private copy to `ghcr.io/thin-edge/private-test-images/httpd:2.4` for use in the private-registry authentication tests.

**Why merge first:** merging this PR causes the mirror workflow's `GITHUB_TOKEN` to push the private package, which links it to this repository. That link is required for `GITHUB_TOKEN` in the test workflow to pull the package — without it the private-registry tests fail with 403.