### PR TITLE
feat: add periodic orphaned service reconciler

### DIFF
--- a/cli/run/cmd.go
+++ b/cli/run/cmd.go
@@ -54,6 +54,7 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 				EnableEngineEvents:      cliContext.EngineEventsEnabled(),
 				CrashLoopThreshold:      cliContext.GetCrashLoopThreshold(),
 				UseModuleNameForService: cliContext.UseModuleNameForService(),
+				SyncRetryInterval:       cliContext.GetSyncRetryInterval(),
 
 				HTTPHost:       cliContext.GetHTTPHost(),
 				HTTPPort:       cliContext.GetHTTPPort(),
@@ -183,6 +184,11 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 	// Reconcile loop (safety net to retry pending cloud deletions and clean up
 	// stale services independently of events). "0" disables it.
 	viper.SetDefault("reconcile.interval", "30m")
+
+	// Failure-driven retry: how long to wait before retrying a cloud sync
+	// after a failure (e.g. a cloud service deletion failed because the local
+	// Cumulocity proxy was unavailable). "0" disables it.
+	viper.SetDefault("reconcile.retry_interval", "30s")
 
 	// Feature flags
 	viper.SetDefault("events.enabled", true)

--- a/cli/run/cmd.go
+++ b/cli/run/cmd.go
@@ -51,6 +51,7 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 				EnableMetrics:           cliContext.MetricsEnabled(),
 				DeleteFromCloud:         cliContext.DeleteFromCloud(),
 				DeleteOrphans:           cliContext.DeleteOrphans(),
+				OrphansCheckInterval:    cliContext.GetOrphansCheckInterval(),
 				EnableEngineEvents:      cliContext.EngineEventsEnabled(),
 				CrashLoopThreshold:      cliContext.GetCrashLoopThreshold(),
 				UseModuleNameForService: cliContext.UseModuleNameForService(),
@@ -194,6 +195,11 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 	viper.SetDefault("events.enabled", true)
 	viper.SetDefault("delete_from_cloud.enabled", true)
 	viper.SetDefault("delete_from_cloud.orphans", true)
+	// Minimum time between routine checks for orphaned cloud services, to
+	// limit the extra Cumulocity REST calls. The interval is bypassed when an
+	// update removed stale services (when new orphans are likely). "0" checks
+	// on every update.
+	viper.SetDefault("delete_from_cloud.orphans_interval", "1h")
 
 	// Crash loop detection
 	viper.SetDefault("container.crash_loop_threshold", 5)

--- a/cli/run/cmd.go
+++ b/cli/run/cmd.go
@@ -119,6 +119,19 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 				}()
 			}
 
+			// Start the background reconcile loop. It periodically triggers a
+			// full update so that pending cloud deletions are retried and
+			// stale/orphaned services are cleaned up even when no container
+			// engine event or bridge-online MQTT message arrives to trigger it
+			// (e.g. the mapper was stopped while a container-group was removed
+			// and the retained bridge health message was lost).
+			// See https://github.com/thin-edge/tedge-container-plugin/issues/181
+			if interval := cliContext.GetReconcileInterval(); interval > 0 {
+				go func() {
+					_ = backgroundReconcile(ctx, cliContext, application, interval)
+				}()
+			}
+
 			<-stop
 			cancel()
 			application.Stop(false)
@@ -167,6 +180,10 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 	viper.SetDefault("metrics.interval", "300s")
 	viper.SetDefault("metrics.enabled", true)
 
+	// Reconcile loop (safety net to retry pending cloud deletions and clean up
+	// stale services independently of events). "0" disables it.
+	viper.SetDefault("reconcile.interval", "30m")
+
 	// Feature flags
 	viper.SetDefault("events.enabled", true)
 	viper.SetDefault("delete_from_cloud.enabled", true)
@@ -191,6 +208,32 @@ func NewRunCommand(cliContext cli.Cli) *cobra.Command {
 
 	command.Command = cmd
 	return cmd
+}
+
+// backgroundReconcile periodically triggers a full state update so that any
+// cleanup which failed at event time is eventually retried. In particular,
+// when a container/container-group is removed while the Cumulocity mapper is
+// down, the cloud service deletion fails and the entity is intentionally kept
+// in the thin-edge entity store; this loop re-detects it as stale and retries
+// the cloud deletion until it succeeds, without relying on MQTT message
+// delivery (the bridge-online handler) or further container events.
+func backgroundReconcile(ctx context.Context, cliContext cli.Cli, application *app.App, interval time.Duration) error {
+	slog.Info("Starting background reconcile task.", "interval", interval)
+	timerCh := time.NewTicker(interval)
+	defer timerCh.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("Stopping reconcile task")
+			return ctx.Err()
+
+		case <-timerCh.C:
+			slog.Info("Reconciling container state")
+			if err := application.Update(cliContext.GetFilterOptions()); err != nil {
+				slog.Warn("Error reconciling container state.", "err", err)
+			}
+		}
+	}
 }
 
 func backgroundMetric(ctx context.Context, cliContext cli.Cli, application *app.App, interval time.Duration) error {

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -97,6 +97,14 @@ interval = "300s"
 # services. Minimum is "60s". Set to "0" to disable the reconcile loop.
 interval = "30m"
 
+# How long to wait before retrying a cloud sync after a failure, e.g. a cloud
+# service deletion failed because the local Cumulocity proxy was unavailable.
+# The retry repeats until the sync succeeds, so pending deletions are recovered
+# shortly after connectivity returns without waiting for the next reconcile
+# interval or depending on MQTT message delivery. Minimum is "5s". Set to "0"
+# to disable the failure-driven retry.
+retry_interval = "30s"
+
 [events]
 # Enable/disable publishing of container engine events
 enabled = true

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -114,6 +114,12 @@ enabled = true
 enabled = true
 # delete orphaned services (related to containers) from the cloud
 orphans = true
+# Minimum time between routine checks for orphaned cloud services, limiting
+# the additional Cumulocity REST calls the check requires on each update. The
+# interval is bypassed whenever an update removed stale services (that is when
+# new orphans are likely), so cleanup after a container removal is never
+# delayed by it. Set to "0" to check on every update.
+orphans_interval = "1h"
 
 [container_group]
 # Control whether the thin-edge service name for container-group services is

--- a/packaging/config.toml
+++ b/packaging/config.toml
@@ -89,6 +89,14 @@ enabled = true
 # How often the container status/telemetry should be collected. The interval will be the minimal interval as it is the time to sleep between collections
 interval = "300s"
 
+[reconcile]
+# How often the full container state is reconciled with thin-edge.io and the
+# cloud, independently of container engine events or MQTT messages. This acts
+# as a safety net which retries pending cloud deletions (e.g. a container-group
+# was removed while the Cumulocity mapper was down) and removes stale/orphaned
+# services. Minimum is "60s". Set to "0" to disable the reconcile loop.
+interval = "30m"
+
 [events]
 # Enable/disable publishing of container engine events
 enabled = true

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -77,7 +77,11 @@ type App struct {
 	// syncRetryScheduled guards against scheduling more than one concurrent
 	// failure-driven cloud sync retry.
 	syncRetryScheduled atomic.Bool
-	wg                 sync.WaitGroup
+	// lastOrphansCheck records when the orphaned cloud services check last
+	// completed successfully, used to enforce OrphansCheckInterval. Only
+	// accessed from the worker goroutine (doUpdate), so it needs no locking.
+	lastOrphansCheck time.Time
+	wg               sync.WaitGroup
 }
 
 type Config struct {
@@ -127,6 +131,15 @@ type Config struct {
 	// https://github.com/thin-edge/thin-edge.io/issues/3185).
 	// A value of 0 (or less) disables the failure-driven retry.
 	SyncRetryInterval time.Duration
+
+	// OrphansCheckInterval is the minimum time between routine checks for
+	// orphaned cloud services, limiting the additional Cumulocity REST calls
+	// the check costs on each update. The interval is bypassed whenever an
+	// update removed stale services, since that is when new orphans are
+	// likely, so cleanup after a container removal is never delayed by it.
+	// A value of 0 (or less) checks on every update.
+	// Only applies when DeleteFromCloud and DeleteOrphans are enabled.
+	OrphansCheckInterval time.Duration
 }
 
 func NewApp(device tedge.Target, config Config) (*App, error) {
@@ -1012,6 +1025,7 @@ func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 	// scheduleSyncRetry) so the next attempt does not depend on an external
 	// trigger.
 	cloudSyncPending := false
+	staleServicesRemoved := false
 	if removeStaleServices {
 		slog.Info("Checking for any stale services")
 		for staleTopicID := range existingServices {
@@ -1035,15 +1049,32 @@ func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 			if err := tedgeClient.DeregisterEntity(*target); err != nil {
 				slog.Warn("Failed to deregister entity.", "err", err)
 			}
+			staleServicesRemoved = true
 			delete(entities, staleTopicID)
 		}
 	}
 
-	// Delete orphaned cloud services
+	// Delete orphaned cloud services. The check is throttled by
+	// OrphansCheckInterval to limit the extra Cumulocity REST calls, but the
+	// interval only applies to routine sweeps: when a stale service was just
+	// removed an orphaned cloud service is likely (deleting by external ID
+	// reports success when the identity does not exist, leaving a managed
+	// object which only the sweep can find), so the check runs regardless.
+	// A failed check does not count as a completed one, so it is retried on
+	// the next update regardless of the interval.
 	if a.config.DeleteFromCloud && a.config.DeleteOrphans {
-		if err := a.DeleteOrphanedCloudServices(entities); err != nil {
-			slog.Warn("Could not delete orphaned cloud services.", "err", err)
-			cloudSyncPending = true
+		checkDue := a.config.OrphansCheckInterval <= 0 ||
+			staleServicesRemoved ||
+			time.Since(a.lastOrphansCheck) >= a.config.OrphansCheckInterval
+		if checkDue {
+			if err := a.DeleteOrphanedCloudServices(entities); err != nil {
+				slog.Warn("Could not delete orphaned cloud services.", "err", err)
+				cloudSyncPending = true
+			} else {
+				a.lastOrphansCheck = time.Now()
+			}
+		} else {
+			slog.Debug("Skipping orphaned cloud services check.", "last", a.lastOrphansCheck, "interval", a.config.OrphansCheckInterval)
 		}
 	}
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -74,7 +74,10 @@ type App struct {
 	// eventLimiter rate-limits per-(container, event-type) MQTT publishes so
 	// that a crash-looping container cannot flood the broker.
 	eventLimiter *EventRateLimiter
-	wg           sync.WaitGroup
+	// syncRetryScheduled guards against scheduling more than one concurrent
+	// failure-driven cloud sync retry.
+	syncRetryScheduled atomic.Bool
+	wg                 sync.WaitGroup
 }
 
 type Config struct {
@@ -114,6 +117,16 @@ type Config struct {
 	// decoupled from the software module name, e.g. the module is "myapp-dev"
 	// but the compose project name (and therefore the service name) is "myapp".
 	UseModuleNameForService bool
+
+	// SyncRetryInterval is the delay before a failed cloud sync is retried,
+	// e.g. a stale service which could not be deleted from the cloud because
+	// the local Cumulocity proxy was unavailable. The retry is scheduled by
+	// the plugin itself so pending operations recover even when no container
+	// engine event or bridge health message arrives to trigger an update (the
+	// health message can be lost entirely, see
+	// https://github.com/thin-edge/thin-edge.io/issues/3185).
+	// A value of 0 (or less) disables the failure-driven retry.
+	SyncRetryInterval time.Duration
 }
 
 func NewApp(device tedge.Target, config Config) (*App, error) {
@@ -424,6 +437,29 @@ func (a *App) Update(filterOptions container.FilterOptions) error {
 		result:  result,
 	}
 	return <-result
+}
+
+// scheduleSyncRetry schedules a full update after the configured retry
+// interval so that pending cloud operations (e.g. service deletions which
+// failed because the local Cumulocity proxy was unavailable) are retried
+// without depending on an external trigger. Container engine events stop once
+// the container is gone, and the bridge health message can be lost entirely
+// (see https://github.com/thin-edge/thin-edge.io/issues/3185), which would
+// otherwise leave the cloud out of sync until the next periodic reconcile.
+// Only one retry is scheduled at a time; if the retried update fails again it
+// reschedules itself, effectively polling until the sync succeeds.
+func (a *App) scheduleSyncRetry() {
+	if a.config.SyncRetryInterval <= 0 || a.config.RunOnce {
+		return
+	}
+	if !a.syncRetryScheduled.CompareAndSwap(false, true) {
+		return
+	}
+	slog.Info("Scheduling retry of pending cloud sync.", "delay", a.config.SyncRetryInterval)
+	time.AfterFunc(a.config.SyncRetryInterval, func() {
+		a.syncRetryScheduled.Store(false)
+		a.debouncer.Enqueue(NewUpdateAllAction(container.FilterOptions{}))
+	})
 }
 
 func (a *App) UpdateMetrics(filterOptions container.FilterOptions) error {
@@ -972,6 +1008,10 @@ func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 	// entity remains in the thin-edge entity store. The next doUpdate() will
 	// detect it as stale again and retry — including after a process restart,
 	// which is why an in-memory pending-deletions queue is insufficient.
+	// Any failure also schedules a failure-driven retry (see
+	// scheduleSyncRetry) so the next attempt does not depend on an external
+	// trigger.
+	cloudSyncPending := false
 	if removeStaleServices {
 		slog.Info("Checking for any stale services")
 		for staleTopicID := range existingServices {
@@ -986,6 +1026,7 @@ func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 					slog.Info("Removing service from the cloud", "topic", target.Topic())
 					if _, err := tedgeClient.DeleteCumulocityManagedObject(*target); err != nil {
 						slog.Warn("Failed to delete managed object, will retry on next update.", "err", err, "topic", target.Topic())
+						cloudSyncPending = true
 						continue
 					}
 				}
@@ -1002,7 +1043,14 @@ func (a *App) doUpdate(filterOptions container.FilterOptions) error {
 	if a.config.DeleteFromCloud && a.config.DeleteOrphans {
 		if err := a.DeleteOrphanedCloudServices(entities); err != nil {
 			slog.Warn("Could not delete orphaned cloud services.", "err", err)
+			cloudSyncPending = true
 		}
+	}
+
+	// Retry later when some cloud-side cleanup could not be completed, so the
+	// pending work is recovered without relying on an external trigger.
+	if cloudSyncPending {
+		a.scheduleSyncRetry()
 	}
 
 	// Update tedge-agent log types

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -218,6 +218,25 @@ func (c *Cli) GetMetricsInterval() time.Duration {
 	return interval
 }
 
+// GetReconcileInterval returns how often the full container state should be
+// reconciled with thin-edge.io and the cloud, independently of container
+// engine events or MQTT messages. The reconcile loop is a safety net which
+// retries pending cloud deletions and removes stale/orphaned services even
+// when the event that should have triggered the cleanup was lost (e.g. the
+// bridge-online message was missed due to retained message loss).
+// A value of 0 (or less) disables the reconcile loop.
+func (c *Cli) GetReconcileInterval() time.Duration {
+	interval := viper.GetDuration("reconcile.interval")
+	if interval <= 0 {
+		return 0
+	}
+	if interval < 60*time.Second {
+		slog.Warn("reconcile.interval is lower than allowed limit.", "old", interval, "new", 60*time.Second)
+		interval = 60 * time.Second
+	}
+	return interval
+}
+
 func (c *Cli) GetMQTTPort() uint16 {
 	v := viper.GetUint16("client.mqtt.port")
 	if v == 0 {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -237,6 +237,24 @@ func (c *Cli) GetReconcileInterval() time.Duration {
 	return interval
 }
 
+// GetSyncRetryInterval returns the delay before a failed cloud sync is
+// retried, e.g. a pending cloud service deletion which failed because the
+// local Cumulocity proxy was unavailable. The retry is scheduled by the
+// plugin itself so pending operations recover even when no container engine
+// event or bridge health message arrives to trigger an update.
+// A value of 0 (or less) disables the failure-driven retry.
+func (c *Cli) GetSyncRetryInterval() time.Duration {
+	interval := viper.GetDuration("reconcile.retry_interval")
+	if interval <= 0 {
+		return 0
+	}
+	if interval < 5*time.Second {
+		slog.Warn("reconcile.retry_interval is lower than allowed limit.", "old", interval, "new", 5*time.Second)
+		interval = 5 * time.Second
+	}
+	return interval
+}
+
 func (c *Cli) GetMQTTPort() uint16 {
 	v := viper.GetUint16("client.mqtt.port")
 	if v == 0 {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -173,6 +173,19 @@ func (c *Cli) DeleteOrphans() bool {
 	return viper.GetBool("delete_from_cloud.orphans")
 }
 
+// GetOrphansCheckInterval returns the minimum time between routine checks
+// for orphaned cloud services. The check costs additional Cumulocity REST
+// calls on each update, so it is rate limited (the interval is bypassed when
+// an update removed stale services, when new orphans are likely).
+// A value of 0 (or less) checks on every update.
+func (c *Cli) GetOrphansCheckInterval() time.Duration {
+	interval := viper.GetDuration("delete_from_cloud.orphans_interval")
+	if interval <= 0 {
+		return 0
+	}
+	return interval
+}
+
 func (c *Cli) GetCrashLoopThreshold() int {
 	return viper.GetInt("container.crash_loop_threshold")
 }

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -178,7 +178,78 @@ Remove Orphaned Cloud Services eventually if Cumulocity Proxy is Unavailable at 
     Cumulocity.Should Have Services    name=manualapp5    min_count=0    max_count=0    timeout=10
     Cumulocity.Should Have Services    name=app6@httpd    min_count=0    max_count=0    timeout=10
 
+Remove orphaned cloud services via periodic reconciliation when bridge health messages are lost
+    [Documentation]    Deterministic reproduction of the root cause of
+    ...    https://github.com/thin-edge/tedge-container-plugin/issues/181
+    ...
+    ...    A container-group is removed while tedge-mapper-c8y (and therefore the local
+    ...    Cumulocity proxy) is down, so the plugin's cloud service deletion fails and
+    ...    is left pending. Normally the bridge-online handler retries it as soon as the
+    ...    mapper's health message arrives, however that message can be lost in the field
+    ...    (retained message loss in mosquitto 2.0.11-2.2.0, thin-edge/thin-edge.io#3185),
+    ...    leaving the service in the cloud forever with an "Unknown" status.
+    ...
+    ...    The message loss is simulated deterministically: the plugin is suspended
+    ...    (SIGSTOP) and mosquitto is restarted so the plugin's MQTT session is dropped
+    ...    while it cannot react. The mapper is started while the plugin is disconnected,
+    ...    and the retained bridge health messages are cleared before the plugin is
+    ...    resumed. The plugin then reconnects and resubscribes, but no bridge-online
+    ...    health message exists or arrives, so only the timer-based background reconcile
+    ...    loop is able to clean up the orphaned cloud service.
+
+    # Speed up the background reconcile loop (60s is the allowed minimum). Restart to
+    # apply it before the orphan is created, so the startup-time update does not
+    # interfere with the test. Builds without the reconcile loop ignore this setting.
+    DeviceLibrary.Execute Command    cmd=echo 'CONTAINER_RECONCILE_INTERVAL=60s' | sudo tee -a /etc/tedge-container-plugin/env
+    DeviceLibrary.Execute Command    cmd=sudo systemctl restart tedge-container-plugin
+
+    # Install a container-group via the cloud (mapper is up)
+    Install container-group application    app10    1.0.0    app10    ${CURDIR}/data/apps/app5.tar.gz
+    Device Should Have Installed Software    {"name": "app10", "version": "1.0.0", "softwareType": "container-group"}
+    Cumulocity.Should Have Services    name=app10@httpd    service_type=container-group    status=up
+
+    # Stop the mapper so the local Cumulocity proxy is unavailable, then remove
+    # the container-group locally. The plugin reacts to the container removal
+    # events and attempts to delete the cloud service, which fails because the
+    # proxy is down, leaving the deletion pending (the entity intentionally stays
+    # in the thin-edge.io entity store so it can be retried).
+    Stop Service    tedge-mapper-c8y
+    DeviceLibrary.Execute Command    cmd=sudo /etc/tedge/sm-plugins/container-group remove app10 --module-version 1.0.0
+    Wait Until Keyword Succeeds    30x    2s    Container Group Should Be Removed Locally    app10
+    Sleep    10s    reason=Let the plugin process the removal events and fail the pending cloud deletion
+
+    # Suspend the plugin, then restart mosquitto so the plugin's MQTT session is
+    # dropped while it cannot react: everything published between now and the
+    # moment it resumes and reconnects is invisible to it.
+    DeviceLibrary.Execute Command    cmd=sudo systemctl kill --signal=STOP --kill-who=main tedge-container-plugin
+    DeviceLibrary.Execute Command    cmd=sudo systemctl restart mosquitto
+
+    # Bring the mapper back online while the plugin is suspended/disconnected, then
+    # clear the retained bridge health messages, simulating the retained message
+    # loss of mosquitto 2.0.11-2.2.0 (thin-edge/thin-edge.io#3185)
+    Start Service    tedge-mapper-c8y
+    Sleep    10s    reason=Allow the mapper to connect and publish its health messages
+    DeviceLibrary.Execute Command    cmd=for name in tedge-mapper-c8y tedge-mapper-bridge-c8y mosquitto-c8y-bridge; do sudo tedge mqtt pub --retain --qos 1 "te/device/main/service/$name/status/health" ''; done
+
+    # Resume the plugin: it reconnects and resubscribes, but no bridge-online
+    # health message exists or arrives, so the bridge-online handler never fires
+    DeviceLibrary.Execute Command    cmd=sudo systemctl kill --signal=CONT --kill-who=main tedge-container-plugin
+
+    # Only the periodic reconciliation can clean up the orphaned cloud service now
+    Cumulocity.Should Have Services    name=app10@httpd    min_count=0    max_count=0    timeout=180
+
+    # Confirm the cleanup was driven by the background reconcile loop
+    DeviceLibrary.Execute Command    cmd=sudo journalctl -u tedge-container-plugin -n 5000 | grep "Reconciling container state"
+
 *** Keywords ***
+
+Container Group Should Be Removed Locally
+    [Documentation]    Device-local check that a container-group module is no longer
+    ...    installed, using the container-group sm-plugin list interface. Used while
+    ...    the Cumulocity mapper is stopped, when the cloud software list cannot update.
+    [Arguments]    ${name}
+    ${output}=    DeviceLibrary.Execute Command    cmd=sudo /etc/tedge/sm-plugins/container-group list    strip=${True}
+    Should Not Contain    ${output}    ${name}
 
 Suite Setup
     ${DEVICE_SN}=    Setup

--- a/tests/operations.robot
+++ b/tests/operations.robot
@@ -150,6 +150,11 @@ Remove Orphaned Cloud Services eventually if Cumulocity Proxy is Unavailable at 
     ...    the device went offline at the time of installation or removal of a container
     ...    or container-group.
     ...    See https://github.com/thin-edge/tedge-container-plugin/issues/181
+    ...
+    ...    The delayed sync is recovered by the bridge-online handler (when the mapper
+    ...    health message arrives) or by the failure-driven retry (reconcile.retry_interval,
+    ...    default 30s) when that message is lost (thin-edge/thin-edge.io#3185), so the
+    ...    cleanup can legitimately take up to ~60s after the mapper is back online.
     DeviceLibrary.Execute Command    cmd=sudo tedge-container engine docker rm -f manualapp5; sleep 1
 
     # create a local container manually
@@ -174,9 +179,13 @@ Remove Orphaned Cloud Services eventually if Cumulocity Proxy is Unavailable at 
     Sleep    15s
     Start Service    tedge-mapper-c8y
 
-    # Services should be eventually deleted
-    Cumulocity.Should Have Services    name=manualapp5    min_count=0    max_count=0    timeout=10
-    Cumulocity.Should Have Services    name=app6@httpd    min_count=0    max_count=0    timeout=10
+    # Services should be eventually deleted. The timeout must cover a full
+    # failure-driven retry cycle (the cleanup is not necessarily triggered by
+    # the mapper health message, which can be lost) plus the per-service
+    # deletion time right after the mapper starts (~5s each while the proxy
+    # and cloud connection warm up).
+    Cumulocity.Should Have Services    name=manualapp5    min_count=0    max_count=0    timeout=120
+    Cumulocity.Should Have Services    name=app6@httpd    min_count=0    max_count=0    timeout=120
 
 Remove orphaned cloud services via periodic reconciliation when bridge health messages are lost
     [Documentation]    Deterministic reproduction of the root cause of
@@ -194,8 +203,10 @@ Remove orphaned cloud services via periodic reconciliation when bridge health me
     ...    while it cannot react. The mapper is started while the plugin is disconnected,
     ...    and the retained bridge health messages are cleared before the plugin is
     ...    resumed. The plugin then reconnects and resubscribes, but no bridge-online
-    ...    health message exists or arrives, so only the timer-based background reconcile
-    ...    loop is able to clean up the orphaned cloud service.
+    ...    health message exists or arrives, so the orphaned cloud service can only be
+    ...    cleaned up by the trigger-independent mechanisms: the failure-driven sync
+    ...    retry (reconcile.retry_interval) and the periodic reconcile loop
+    ...    (reconcile.interval).
 
     # Speed up the background reconcile loop (60s is the allowed minimum). Restart to
     # apply it before the orphan is created, so the startup-time update does not
@@ -235,10 +246,13 @@ Remove orphaned cloud services via periodic reconciliation when bridge health me
     # health message exists or arrives, so the bridge-online handler never fires
     DeviceLibrary.Execute Command    cmd=sudo systemctl kill --signal=CONT --kill-who=main tedge-container-plugin
 
-    # Only the periodic reconciliation can clean up the orphaned cloud service now
+    # Only the trigger-independent mechanisms can clean up the orphan now
     Cumulocity.Should Have Services    name=app10@httpd    min_count=0    max_count=0    timeout=180
 
-    # Confirm the cleanup was driven by the background reconcile loop
+    # Confirm the trigger-independent recovery mechanisms ran: the failed cloud
+    # deletion must have scheduled a failure-driven retry, and the periodic
+    # reconcile loop must be ticking
+    DeviceLibrary.Execute Command    cmd=sudo journalctl -u tedge-container-plugin -n 5000 | grep "Scheduling retry of pending cloud sync"
     DeviceLibrary.Execute Command    cmd=sudo journalctl -u tedge-container-plugin -n 5000 | grep "Reconciling container state"
 
 *** Keywords ***


### PR DESCRIPTION
## Summary

Fixes #181 — services were left in the cloud with an "Unknown" status forever when a container/container-group was removed while `tedge-mapper-c8y` was down (e.g. local Cumulocity proxy unavailable).

**Root cause:** the cloud service deletion correctly stayed pending for retry, but the retry only ran when an external trigger arrived (container engine event or bridge health message). After a removal no further container events occur, and the bridge health message can be lost entirely (mosquitto 2.0.11–2.2.0 retained message loss, thin-edge/thin-edge.io#3185) — observed live in CI on Debian 13 (mosquitto 2.0.20). With no trigger, the pending deletion never ran.

## Changes

- **Failure-driven retry** — when an update leaves pending cloud cleanup (stale service deletion or orphan check failed, e.g. proxy down), the plugin now schedules its own retry. It re-arms until the sync succeeds, so cleanup completes ~30s after connectivity returns — no dependency on MQTT delivery or container events.
- **Periodic reconciliation** — a background loop performing a full state sync (pending deletions, stale/orphaned services) as a safety net, independent of any trigger.
- **Rate-limited orphaned cloud service check** — checking the cloud for orphaned services costs extra Cumulocity REST calls on every update, so routine checks are now rate limited. The interval is bypassed whenever an update removed stale services (exactly when new orphans are likely), so cleanup after a removal is never delayed. ⚠️ Behavior change: previously the check ran on every update.

## Configuration

```toml
[reconcile]
# Full state reconciliation interval (safety net). Min "60s", "0" disables
interval = "30m"

# Delay before retrying a failed cloud sync (e.g. proxy was unavailable).
# Repeats until the sync succeeds. Min "5s", "0" disables
retry_interval = "30s"

[delete_from_cloud]
# Minimum time between routine checks for orphaned cloud services.
# Bypassed when an update removed stale services. "0" checks on every update
orphans_interval = "1h"
```

All values can also be set via env, e.g. `CONTAINER_RECONCILE_RETRY_INTERVAL=30s`.

## Tests

- New system test reproducing the root cause deterministically: the bridge health message loss is simulated (plugin suspended while mosquitto restarts and the mapper comes back, retained health messages cleared), so cleanup can only come from the trigger-independent mechanisms. Verified to fail on the previous build and pass with this PR.
- `Remove Orphaned Cloud Services eventually if Cumulocity Proxy is Unavailable at deletion time` was flaky in CI (the lost health message scenario occurring naturally, plus assertion timeouts too tight for the ~5s/service deletion time right after mapper start). Now deterministic via the retry mechanism; timeouts raised to cover a full retry cycle.