### PR TITLE
fix: ignore newline character as the end of environment variables

### DIFF
--- a/packaging/services/s6-overlay/tedge-container-plugin/run
+++ b/packaging/services/s6-overlay/tedge-container-plugin/run
@@ -32,7 +32,7 @@ trap -x
 }
 
 # with-contenv
-s6-envdir -Lfn -- /run/s6/container_environment
+s6-envdir -L -- /run/s6/container_environment
 
 # Redirect stderr to stdout
 fdmove -c 2 1


### PR DESCRIPTION
Fix https://github.com/thin-edge/tedge-container-plugin/issues/222, when starting a container using the s6-overlay definitions, results in any environment variables passed to the container having a trailing `\n` character which can breaks the reading of the values.