### PR TITLE
fix: fix parsing of env variables in different situations

### DIFF
--- a/packaging/services/s6-overlay/tedge-container-plugin/run
+++ b/packaging/services/s6-overlay/tedge-container-plugin/run
@@ -32,7 +32,7 @@ trap -x
 }
 
 # with-contenv
-s6-envdir -L -- /run/s6/container_environment
+s6-envdir -Lf -- /run/s6/container_environment
 
 # Redirect stderr to stdout
 fdmove -c 2 1


### PR DESCRIPTION
Fixes https://github.com/thin-edge/tedge-container-plugin/issues/224